### PR TITLE
Add Vagrantfiles for CI

### DIFF
--- a/.github/vagrantfiles/amazon2-amd64-build/Vagrantfile
+++ b/.github/vagrantfiles/amazon2-amd64-build/Vagrantfile
@@ -1,0 +1,28 @@
+Vagrant.require_version ">= 1.6.2"
+
+Vagrant.configure("2") do |config|
+    config.vm.define "amazon2-amd64-build"
+    config.vm.box = "amazon2-amd64-build"
+    config.vm.box_url = [ "https://s3.eu-central-1.wasabisys.com/blobs-wasabi.elastio.dev/devboxes/master/amazon2-amd64-build/amazon2-amd64-build.box" ]
+
+    $set_environment_variables = <<ENV_VARS_SCRIPT
+      tee /etc/profile.d/set_build_env.sh > /dev/null <<EOF
+export AWS_ACCESS_KEY_ID=#{ENV['AWS_ACCESS_KEY_ID']}
+export AWS_DEFAULT_REGION=#{ENV['AWS_DEFAULT_REGION']}
+export SOURCE_BRANCH=#{ENV['SOURCE_BRANCH']}
+export REPO_PATH=#{ENV['REPO_PATH']}
+export PKG_TYPE=#{ENV['PKG_TYPE']}
+export DIST_NAME=#{ENV['DIST_NAME']}
+export DIST_VER=#{ENV['DIST_VER']}
+export GITHUB_EVENT_NAME=#{ENV['GITHUB_EVENT_NAME']}
+export GITHUB_RUN_NUMBER=#{ENV['GITHUB_RUN_NUMBER']}
+EOF
+      chmod +x /etc/profile.d/set_build_env.sh
+ENV_VARS_SCRIPT
+
+    config.vm.provision "shell", inline: $set_environment_variables, run: "always"
+
+    config.vm.synced_folder "../../../", "/home/elastio/elastio-snap", type: "rsync",
+      rsync__args: ["-rLkz", "--delete", "--filter=:- .gitignore"], rsync__exclude: [".vagrant/"]
+
+end

--- a/.github/vagrantfiles/centos6-amd64-build/Vagrantfile
+++ b/.github/vagrantfiles/centos6-amd64-build/Vagrantfile
@@ -1,0 +1,28 @@
+Vagrant.require_version ">= 1.6.2"
+
+Vagrant.configure("2") do |config|
+    config.vm.define "centos6-amd64-build"
+    config.vm.box = "centos6-amd64-build"
+    config.vm.box_url = [ "https://s3.eu-central-1.wasabisys.com/blobs-wasabi.elastio.dev/devboxes/master/centos6-amd64-build/centos6-amd64-build.box" ]
+
+    $set_environment_variables = <<ENV_VARS_SCRIPT
+      tee /etc/profile.d/set_build_env.sh > /dev/null <<EOF
+export AWS_ACCESS_KEY_ID=#{ENV['AWS_ACCESS_KEY_ID']}
+export AWS_DEFAULT_REGION=#{ENV['AWS_DEFAULT_REGION']}
+export SOURCE_BRANCH=#{ENV['SOURCE_BRANCH']}
+export REPO_PATH=#{ENV['REPO_PATH']}
+export PKG_TYPE=#{ENV['PKG_TYPE']}
+export DIST_NAME=#{ENV['DIST_NAME']}
+export DIST_VER=#{ENV['DIST_VER']}
+export GITHUB_EVENT_NAME=#{ENV['GITHUB_EVENT_NAME']}
+export GITHUB_RUN_NUMBER=#{ENV['GITHUB_RUN_NUMBER']}
+EOF
+      chmod +x /etc/profile.d/set_build_env.sh
+ENV_VARS_SCRIPT
+
+    config.vm.provision "shell", inline: $set_environment_variables, run: "always"
+
+    config.vm.synced_folder "../../../", "/home/elastio/elastio-snap", type: "rsync",
+      rsync__args: ["-rLkz", "--delete", "--filter=:- .gitignore"], rsync__exclude: [".vagrant/"]
+
+end

--- a/.github/vagrantfiles/centos7-amd64-build/Vagrantfile
+++ b/.github/vagrantfiles/centos7-amd64-build/Vagrantfile
@@ -1,0 +1,28 @@
+Vagrant.require_version ">= 1.6.2"
+
+Vagrant.configure("2") do |config|
+    config.vm.define "centos7-amd64-build"
+    config.vm.box = "centos7-amd64-build"
+    config.vm.box_url = [ "https://s3.eu-central-1.wasabisys.com/blobs-wasabi.elastio.dev/devboxes/master/centos7-amd64-build/centos7-amd64-build.box" ]
+
+    $set_environment_variables = <<ENV_VARS_SCRIPT
+      tee /etc/profile.d/set_build_env.sh > /dev/null <<EOF
+export AWS_ACCESS_KEY_ID=#{ENV['AWS_ACCESS_KEY_ID']}
+export AWS_DEFAULT_REGION=#{ENV['AWS_DEFAULT_REGION']}
+export SOURCE_BRANCH=#{ENV['SOURCE_BRANCH']}
+export REPO_PATH=#{ENV['REPO_PATH']}
+export PKG_TYPE=#{ENV['PKG_TYPE']}
+export DIST_NAME=#{ENV['DIST_NAME']}
+export DIST_VER=#{ENV['DIST_VER']}
+export GITHUB_EVENT_NAME=#{ENV['GITHUB_EVENT_NAME']}
+export GITHUB_RUN_NUMBER=#{ENV['GITHUB_RUN_NUMBER']}
+EOF
+      chmod +x /etc/profile.d/set_build_env.sh
+ENV_VARS_SCRIPT
+
+    config.vm.provision "shell", inline: $set_environment_variables, run: "always"
+
+    config.vm.synced_folder "../../../", "/home/elastio/elastio-snap", type: "rsync",
+      rsync__args: ["-rLkz", "--delete", "--filter=:- .gitignore"], rsync__exclude: [".vagrant/"]
+
+end

--- a/.github/vagrantfiles/centos8-amd64-build/Vagrantfile
+++ b/.github/vagrantfiles/centos8-amd64-build/Vagrantfile
@@ -1,0 +1,28 @@
+Vagrant.require_version ">= 1.6.2"
+
+Vagrant.configure("2") do |config|
+    config.vm.define "centos8-amd64-build"
+    config.vm.box = "centos8-amd64-build"
+    config.vm.box_url = [ "https://s3.eu-central-1.wasabisys.com/blobs-wasabi.elastio.dev/devboxes/master/centos8-amd64-build/centos8-amd64-build.box" ]
+
+    $set_environment_variables = <<ENV_VARS_SCRIPT
+      tee /etc/profile.d/set_build_env.sh > /dev/null <<EOF
+export AWS_ACCESS_KEY_ID=#{ENV['AWS_ACCESS_KEY_ID']}
+export AWS_DEFAULT_REGION=#{ENV['AWS_DEFAULT_REGION']}
+export SOURCE_BRANCH=#{ENV['SOURCE_BRANCH']}
+export REPO_PATH=#{ENV['REPO_PATH']}
+export PKG_TYPE=#{ENV['PKG_TYPE']}
+export DIST_NAME=#{ENV['DIST_NAME']}
+export DIST_VER=#{ENV['DIST_VER']}
+export GITHUB_EVENT_NAME=#{ENV['GITHUB_EVENT_NAME']}
+export GITHUB_RUN_NUMBER=#{ENV['GITHUB_RUN_NUMBER']}
+EOF
+      chmod +x /etc/profile.d/set_build_env.sh
+ENV_VARS_SCRIPT
+
+    config.vm.provision "shell", inline: $set_environment_variables, run: "always"
+
+    config.vm.synced_folder "../../../", "/home/elastio/elastio-snap", type: "rsync",
+      rsync__args: ["-rLkz", "--delete", "--filter=:- .gitignore"], rsync__exclude: [".vagrant/"]
+
+end

--- a/.github/vagrantfiles/debian10-amd64-build/Vagrantfile
+++ b/.github/vagrantfiles/debian10-amd64-build/Vagrantfile
@@ -1,0 +1,28 @@
+Vagrant.require_version ">= 1.6.2"
+
+Vagrant.configure("2") do |config|
+    config.vm.define "debian10-amd64-build"
+    config.vm.box = "debian10-amd64-build"
+    config.vm.box_url = [ "https://s3.eu-central-1.wasabisys.com/blobs-wasabi.elastio.dev/devboxes/master/debian10-amd64-build/debian10-amd64-build.box" ]
+
+    $set_environment_variables = <<ENV_VARS_SCRIPT
+      tee /etc/profile.d/set_build_env.sh > /dev/null <<EOF
+export AWS_ACCESS_KEY_ID=#{ENV['AWS_ACCESS_KEY_ID']}
+export AWS_DEFAULT_REGION=#{ENV['AWS_DEFAULT_REGION']}
+export SOURCE_BRANCH=#{ENV['SOURCE_BRANCH']}
+export REPO_PATH=#{ENV['REPO_PATH']}
+export PKG_TYPE=#{ENV['PKG_TYPE']}
+export DIST_NAME=#{ENV['DIST_NAME']}
+export DIST_VER=#{ENV['DIST_VER']}
+export GITHUB_EVENT_NAME=#{ENV['GITHUB_EVENT_NAME']}
+export GITHUB_RUN_NUMBER=#{ENV['GITHUB_RUN_NUMBER']}
+EOF
+      chmod +x /etc/profile.d/set_build_env.sh
+ENV_VARS_SCRIPT
+
+    config.vm.provision "shell", inline: $set_environment_variables, run: "always"
+
+    config.vm.synced_folder "../../../", "/home/elastio/elastio-snap", type: "rsync",
+      rsync__args: ["-rLkz", "--delete", "--filter=:- .gitignore"], rsync__exclude: [".vagrant/"]
+
+end

--- a/.github/vagrantfiles/debian8-amd64-build/Vagrantfile
+++ b/.github/vagrantfiles/debian8-amd64-build/Vagrantfile
@@ -1,0 +1,28 @@
+Vagrant.require_version ">= 1.6.2"
+
+Vagrant.configure("2") do |config|
+    config.vm.define "debian8-amd64-build"
+    config.vm.box = "debian8-amd64-build"
+    config.vm.box_url = [ "https://s3.eu-central-1.wasabisys.com/blobs-wasabi.elastio.dev/devboxes/master/debian8-amd64-build/debian8-amd64-build.box" ]
+
+    $set_environment_variables = <<ENV_VARS_SCRIPT
+      tee /etc/profile.d/set_build_env.sh > /dev/null <<EOF
+export AWS_ACCESS_KEY_ID=#{ENV['AWS_ACCESS_KEY_ID']}
+export AWS_DEFAULT_REGION=#{ENV['AWS_DEFAULT_REGION']}
+export SOURCE_BRANCH=#{ENV['SOURCE_BRANCH']}
+export REPO_PATH=#{ENV['REPO_PATH']}
+export PKG_TYPE=#{ENV['PKG_TYPE']}
+export DIST_NAME=#{ENV['DIST_NAME']}
+export DIST_VER=#{ENV['DIST_VER']}
+export GITHUB_EVENT_NAME=#{ENV['GITHUB_EVENT_NAME']}
+export GITHUB_RUN_NUMBER=#{ENV['GITHUB_RUN_NUMBER']}
+EOF
+      chmod +x /etc/profile.d/set_build_env.sh
+ENV_VARS_SCRIPT
+
+    config.vm.provision "shell", inline: $set_environment_variables, run: "always"
+
+    config.vm.synced_folder "../../../", "/home/elastio/elastio-snap", type: "rsync",
+      rsync__args: ["-rLkz", "--delete", "--filter=:- .gitignore"], rsync__exclude: [".vagrant/"]
+
+end

--- a/.github/vagrantfiles/debian9-amd64-build/Vagrantfile
+++ b/.github/vagrantfiles/debian9-amd64-build/Vagrantfile
@@ -1,0 +1,28 @@
+Vagrant.require_version ">= 1.6.2"
+
+Vagrant.configure("2") do |config|
+    config.vm.define "debian9-amd64-build"
+    config.vm.box = "debian9-amd64-build"
+    config.vm.box_url = [ "https://s3.eu-central-1.wasabisys.com/blobs-wasabi.elastio.dev/devboxes/master/debian9-amd64-build/debian9-amd64-build.box" ]
+
+    $set_environment_variables = <<ENV_VARS_SCRIPT
+      tee /etc/profile.d/set_build_env.sh > /dev/null <<EOF
+export AWS_ACCESS_KEY_ID=#{ENV['AWS_ACCESS_KEY_ID']}
+export AWS_DEFAULT_REGION=#{ENV['AWS_DEFAULT_REGION']}
+export SOURCE_BRANCH=#{ENV['SOURCE_BRANCH']}
+export REPO_PATH=#{ENV['REPO_PATH']}
+export PKG_TYPE=#{ENV['PKG_TYPE']}
+export DIST_NAME=#{ENV['DIST_NAME']}
+export DIST_VER=#{ENV['DIST_VER']}
+export GITHUB_EVENT_NAME=#{ENV['GITHUB_EVENT_NAME']}
+export GITHUB_RUN_NUMBER=#{ENV['GITHUB_RUN_NUMBER']}
+EOF
+      chmod +x /etc/profile.d/set_build_env.sh
+ENV_VARS_SCRIPT
+
+    config.vm.provision "shell", inline: $set_environment_variables, run: "always"
+
+    config.vm.synced_folder "../../../", "/home/elastio/elastio-snap", type: "rsync",
+      rsync__args: ["-rLkz", "--delete", "--filter=:- .gitignore"], rsync__exclude: [".vagrant/"]
+
+end

--- a/.github/vagrantfiles/fedora31-amd64-build/Vagrantfile
+++ b/.github/vagrantfiles/fedora31-amd64-build/Vagrantfile
@@ -1,0 +1,28 @@
+Vagrant.require_version ">= 1.6.2"
+
+Vagrant.configure("2") do |config|
+    config.vm.define "fedora31-amd64-build"
+    config.vm.box = "fedora31-amd64-build"
+    config.vm.box_url = [ "https://s3.eu-central-1.wasabisys.com/blobs-wasabi.elastio.dev/devboxes/master/fedora31-amd64-build/fedora31-amd64-build.box" ]
+
+    $set_environment_variables = <<ENV_VARS_SCRIPT
+      tee /etc/profile.d/set_build_env.sh > /dev/null <<EOF
+export AWS_ACCESS_KEY_ID=#{ENV['AWS_ACCESS_KEY_ID']}
+export AWS_DEFAULT_REGION=#{ENV['AWS_DEFAULT_REGION']}
+export SOURCE_BRANCH=#{ENV['SOURCE_BRANCH']}
+export REPO_PATH=#{ENV['REPO_PATH']}
+export PKG_TYPE=#{ENV['PKG_TYPE']}
+export DIST_NAME=#{ENV['DIST_NAME']}
+export DIST_VER=#{ENV['DIST_VER']}
+export GITHUB_EVENT_NAME=#{ENV['GITHUB_EVENT_NAME']}
+export GITHUB_RUN_NUMBER=#{ENV['GITHUB_RUN_NUMBER']}
+EOF
+      chmod +x /etc/profile.d/set_build_env.sh
+ENV_VARS_SCRIPT
+
+    config.vm.provision "shell", inline: $set_environment_variables, run: "always"
+
+    config.vm.synced_folder "../../../", "/home/elastio/elastio-snap", type: "rsync",
+      rsync__args: ["-rLkz", "--delete", "--filter=:- .gitignore"], rsync__exclude: [".vagrant/"]
+
+end

--- a/.github/vagrantfiles/fedora32-amd64-build/Vagrantfile
+++ b/.github/vagrantfiles/fedora32-amd64-build/Vagrantfile
@@ -1,0 +1,28 @@
+Vagrant.require_version ">= 1.6.2"
+
+Vagrant.configure("2") do |config|
+    config.vm.define "fedora32-amd64-build"
+    config.vm.box = "fedora32-amd64-build"
+    config.vm.box_url = [ "https://s3.eu-central-1.wasabisys.com/blobs-wasabi.elastio.dev/devboxes/master/fedora32-amd64-build/fedora32-amd64-build.box" ]
+
+    $set_environment_variables = <<ENV_VARS_SCRIPT
+      tee /etc/profile.d/set_build_env.sh > /dev/null <<EOF
+export AWS_ACCESS_KEY_ID=#{ENV['AWS_ACCESS_KEY_ID']}
+export AWS_DEFAULT_REGION=#{ENV['AWS_DEFAULT_REGION']}
+export SOURCE_BRANCH=#{ENV['SOURCE_BRANCH']}
+export REPO_PATH=#{ENV['REPO_PATH']}
+export PKG_TYPE=#{ENV['PKG_TYPE']}
+export DIST_NAME=#{ENV['DIST_NAME']}
+export DIST_VER=#{ENV['DIST_VER']}
+export GITHUB_EVENT_NAME=#{ENV['GITHUB_EVENT_NAME']}
+export GITHUB_RUN_NUMBER=#{ENV['GITHUB_RUN_NUMBER']}
+EOF
+      chmod +x /etc/profile.d/set_build_env.sh
+ENV_VARS_SCRIPT
+
+    config.vm.provision "shell", inline: $set_environment_variables, run: "always"
+
+    config.vm.synced_folder "../../../", "/home/elastio/elastio-snap", type: "rsync",
+      rsync__args: ["-rLkz", "--delete", "--filter=:- .gitignore"], rsync__exclude: [".vagrant/"]
+
+end

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,7 @@ jobs:
   build-packages:
     name: Build Packages
     runs-on:
-      - build
-      - self-hosted
-      - ${{ matrix.distro }}
-      - ${{ matrix.arch }}
+      - baremetal
 
     strategy:
       matrix:
@@ -33,30 +30,103 @@ jobs:
 
       - name: Set ENV
         run: |
-          pkg_type=rpm
-          [ -f "/etc/debian_version" ] && pkg_type=deb
-          echo ::set-env name=PKG_TYPE::$(echo $pkg_type)
-          echo ::set-env name=SOURCE_BRANCH::$(git rev-parse --abbrev-ref HEAD)
+          set -x
+          source_branch=$(git rev-parse --abbrev-ref HEAD)
+          echo source_branch:     $source_branch
+          echo ::set-env name=SOURCE_BRANCH::$(echo $source_branch)
+
+          dist_name=$(echo ${{ matrix.distro }} | grep -o -E '[a-z]+')
+          dist_name=$(d=${dist_name^} && echo ${d//os/OS})
+          dist_ver=$(echo ${{ matrix.distro }} | grep -o -E '[0-9]+')
+          case $dist_name in
+            Debian|Ubuntu) pkg_type=deb ;;
+            *)             pkg_type=rpm ;;
+          esac
+          runner_num=$(echo $GITHUB_WORKSPACE | grep -o -E '[0-9]+' | head -1)
+          echo ::set-env name=PKG_TYPE::$pkg_type
+          echo ::set-env name=DIST_NAME::$dist_name
+          echo ::set-env name=DIST_VER::$dist_ver
+          echo ::set-env name=RUNNER_NUM::$runner_num
+          echo ::set-env name=BOX_NAME::$(echo ${{ matrix.distro }}-${{ matrix.arch }}-build)
+          echo ::set-env name=INSTANCE_NAME::$(echo ${{ matrix.distro }}-${{ matrix.arch }}-build-$runner_num)
+
+      - name: Check ENV
+        run: |
+          set -eu
+          echo "The environment variables are set:"
+          echo SOURCE_BRANCH:       $SOURCE_BRANCH
+          echo PKG_TYPE:            $PKG_TYPE
+          echo DIST_NAME:           $DIST_NAME
+          echo DIST_VER:            $DIST_VER
+          echo RUNNER_NUM:          $RUNNER_NUM
+          echo BOX_NAME:            $BOX_NAME
+          echo INSTANCE_NAME:       $INSTANCE_NAME
+          echo LIBVIRT_DEFAULT_URI: $LIBVIRT_DEFAULT_URI
+
+      - name: Start a box
+        env:
+          AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          cd .github/vagrantfiles/$BOX_NAME
+          sed -i '/config.vm.define/c \    config.vm.define "'$INSTANCE_NAME'"' Vagrantfile
+
+          vm_id=$(vagrant global-status --prune | grep $INSTANCE_NAME | cut -d' ' -f1)
+          # it should never happen, but just in case...
+          [ ! -z "$vm_id" ] && vagrant destroy $vm_id --force
+          vagrant up
 
       - name: Build packages
-        run: make ${PKG_TYPE}
+        run: |
+          cd .github/vagrantfiles/$BOX_NAME
+          vagrant ssh -c 'cd elastio-snap && make ${PKG_TYPE}'
 
       - name: Collect artifacts
-        run: repobuild/collect_artifacts.sh
+        run: | 
+          cd .github/vagrantfiles/$BOX_NAME
+          vagrant ssh -c 'cd elastio-snap && repobuild/collect_artifacts.sh'
 
       - name: Upload artifacts
-        run: repobuild/upload.sh
-          --source repobuild/artifacts/
-          --bucket artifacts.assur.io
-          --target /linux/elastio-snap/${SOURCE_BRANCH}/${GITHUB_RUN_NUMBER}/${PKG_TYPE}
-          --exclude *GPG-KEY
+        run: |
+          cd .github/vagrantfiles/$BOX_NAME
+          vagrant ssh -c 'cd elastio-snap && AWS_SECRET_ACCESS_KEY='"'$AWS_SECRET_ACCESS_KEY'"' repobuild/upload.sh \
+            --source repobuild/artifacts/ \
+            --bucket artifacts.assur.io \
+            --target /linux/elastio-snap/${SOURCE_BRANCH}/${GITHUB_RUN_NUMBER}/${PKG_TYPE} \
+            --exclude *GPG-KEY'
+
+      - name: Destroy a box
+        if: always()
+        run: |
+          cd .github/vagrantfiles/$BOX_NAME
+
+          # 'vagrant halt' hungs on Debian 8. Thus, just destroy. It's a bit brutal, but even faster...
+          vagrant destroy --force
+
+          # This should never happen, but as a "last-ditch foul"
+          # in the football, use virsh commands to find and remove lasts of the vagrant image. And then fail a build
+          # to notice this problem (get a red card and go away from the field, yeah).
+          res=0
+          if virsh list --all | grep -q ${BOX_NAME}_${INSTANCE_NAME} ; then
+              virsh destroy ${BOX_NAME}_${INSTANCE_NAME}
+              virsh undefine ${BOX_NAME}_${INSTANCE_NAME}
+              echo "The vagrant box ${BOX_NAME}_${INSTANCE_NAME} was not removed by the 'vagrant destroy --force' and now removed by virsh."
+              res=1
+          fi
+
+          if virsh vol-list default | grep -q ${BOX_NAME}_${INSTANCE_NAME}.img ; then
+              virsh vol-delete --pool default ${BOX_NAME}_${INSTANCE_NAME}.img
+              echo "${BOX_NAME}_${INSTANCE_NAME}.img was not removed by the 'vagrant destroy --force' and now removed by virsh."
+              res=2
+          fi
+
+          exit $res
 
   manifest:
     name: Artifacts manifest
     needs: build-packages
     runs-on:
-      - build
-      - Linux
+      - baremetal
 
     steps:
       - name: Make manifest
@@ -72,8 +142,7 @@ jobs:
     name: Trigger repo upload
     needs: manifest 
     runs-on:
-      - build
-      - Linux
+      - baremetal
 
     steps:
       - name: Dispatch packaging repo

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ __pycache__/
 
 # Project directories
 pkgbuild/
+
+# Vagrant hidden dirs
+.github/vagrantfiles/**/.vagrant


### PR DESCRIPTION
1) Updated ci.yml to use Vagrant boxes for the driver and packages
   build.
2) Added 'start a box', 'destroy a box' build steps.
3) Copied Vagrant files from the packaging and removed all GPG related
   stuff from them.
4) The jobs 'Artifacts manifest' and 'Trigger repo upload' are running
   directly on the baremetal runners. They need just curl and aws cli
   and I don't see any reason to "pack" these simple operations into the
   Vagrant boxes. Also they are distribution independent.

Closes #35 