### PR TITLE
Prevent cancellation of the 'vagrant up' build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set ENV
+        if: always()
         run: |
           set -x
           source_branch=$(git rev-parse --abbrev-ref HEAD)
@@ -66,6 +67,7 @@ jobs:
           echo LIBVIRT_DEFAULT_URI: $LIBVIRT_DEFAULT_URI
 
       - name: Start a box
+        if: always()
         env:
           AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
'if: always()' is added to prevent cancellation of the
'vagrant up' build step. Otherwise, if a build ic cancelled during the
'vagrant up', then 'vagrant destroy' is failing with the long error
messege like here:
https://github.com/elastio/elastio/runs/1110832997?check_suite_focus=true#step:8:55