### PR TITLE
Fix driver build on the Linux kernel v. 5.6

### DIFF
--- a/src/configure-tests/feature-tests/proc_create_fn_file_operations.c
+++ b/src/configure-tests/feature-tests/proc_create_fn_file_operations.c
@@ -5,9 +5,12 @@
  * Additional contributions by Elastio Software, Inc are Copyright (C) 2020 Elastio Software Inc.
  */
 
+// 2.6.25 <= kernel_version < 5.6
+
 #include "includes.h"
 
 static inline void dummy(void){
-	struct proc_dir_entry *ent = proc_create("file", 0, NULL, NULL);
+ 	static const struct file_operations file_ops;
+	struct proc_dir_entry *ent = proc_create("file", 0, NULL, &file_ops);
 	(void)ent;
 }

--- a/src/configure-tests/feature-tests/proc_create_fn_proc_ops.c
+++ b/src/configure-tests/feature-tests/proc_create_fn_proc_ops.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+// 5.6 <= kernel_version
+
+#include "includes.h"
+
+static inline void dummy(void){
+ 	static const struct proc_ops file_ops;
+	struct proc_dir_entry *ent = proc_create("file", 0, NULL, &file_ops);
+	(void)ent;
+}

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -580,7 +580,7 @@ static inline void elastio_snap_inode_unlock(struct inode *inode){
 	#define elastio_snap_inode_unlock inode_unlock
 #endif
 
-#ifndef HAVE_PROC_CREATE
+#if !defined HAVE_PROC_CREATE_FN_FILE_OPERATIONS && !defined HAVE_PROC_CREATE_FN_PROC_OPS
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,25)
 static inline struct proc_dir_entry *proc_create(const char *name, mode_t mode, struct proc_dir_entry *parent, const struct file_operations *proc_fops){
 	struct proc_dir_entry *ent;
@@ -919,6 +919,14 @@ static const struct seq_operations elastio_snap_seq_proc_ops = {
 	.show = elastio_snap_proc_show,
 };
 
+#ifdef HAVE_PROC_CREATE_FN_PROC_OPS
+static const struct proc_ops elastio_snap_proc_fops = {
+	.proc_open = elastio_snap_proc_open,
+	.proc_read = seq_read,
+	.proc_lseek = seq_lseek,
+	.proc_release = elastio_snap_proc_release,
+};
+#else
 static const struct file_operations elastio_snap_proc_fops = {
 	.owner = THIS_MODULE,
 	.open = elastio_snap_proc_open,
@@ -926,6 +934,7 @@ static const struct file_operations elastio_snap_proc_fops = {
 	.llseek = seq_lseek,
 	.release = elastio_snap_proc_release,
 };
+#endif
 
 static int major;
 static struct mutex ioctl_mutex;


### PR DESCRIPTION
- Used structure of the proc_ops type as argument for the proc_create
  function. The prototype of this function is changed since kernel 5.6.

- Updated existing feature test to check argument type for the
  file_operations structure and added new test for the same function and
  another argument of type proc_ops.

This fix resolves #24 about driver build failure on Fedora 31 with the kernel v. 5.6. However Fedora 31 now has kernel v. 5.8.
I'm going to crate another issue for it.