### PR TITLE
Correct some inaccuracies in README.md and INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ The repository install package `elastio-repo` is available for Amazon Linux 2.
 
 ```bash
 # Install repo package
-sudo yum localinstall https://repo.assur.io/master/linux/rpm/Amazon/$(rpm -E %%amzn)/x86_64/Packages/elastio-repo-0.0.2-1.amzn$(rpm -E %amzn).noarch.rpm
+sudo yum localinstall https://repo.assur.io/master/linux/rpm/Amazon/$(rpm -E %amzn)/x86_64/Packages/elastio-repo-0.0.2-1.amzn$(rpm -E %amzn).noarch.rpm
 ```
 
 #### Fedora


### PR DESCRIPTION
Correct snapshot device name in the README.md
- Changed snapshot device name from the  /dev/elastio[N] to the the /dev/elastio-snap[N].
- Highlighted commands as code to make README.md better readable.

Fix typo in the installation instruction for Amazon Linux 2 in the INSTALL.md
- There was an extra % in the link to the Amazon 2 repo package.