### PR TITLE
Fix "floating" bug with undefined source branch on CI

### DIFF
--- a/.github/scripts/detect_branch.sh
+++ b/.github/scripts/detect_branch.sh
@@ -1,6 +1,6 @@
 case $GITHUB_EVENT_NAME in
-  pull_request)          source_branch="${GITHUB_HEAD_REF#refs/heads/}" ;;
-  push)                  source_branch="${GITHUB_REF#refs/heads/}" ;;
-  *)                     source_branch=$(git rev-parse --abbrev-ref HEAD) ;;
+    pull_request) source_branch="${GITHUB_HEAD_REF#refs/heads/}" ;;
+    push)         source_branch="${GITHUB_REF#refs/heads/}" ;;
+    *)            source_branch=$(git rev-parse --abbrev-ref HEAD) ;;
 esac
 echo $source_branch

--- a/.github/scripts/dispatch_packaging.sh
+++ b/.github/scripts/dispatch_packaging.sh
@@ -4,6 +4,6 @@ where_from="from"
 [ "$GITHUB_EVENT_NAME" == "push" ] && where_from="to"
 set -x
 curl -XPOST -u "$REPO_HOOK_TOKEN" \
-  -H "Accept: application/vnd.github.everest-preview+json" \
-  -H "Content-Type: application/json" https://api.github.com/repos/elastio/packaging/dispatches \
-  --data '{ "event_type": "elastio-snap #'$GITHUB_RUN_NUMBER': '$GITHUB_EVENT_NAME' '$where_from' '$SOURCE_BRANCH'", "client_payload": { "branch": "'$SOURCE_BRANCH'" } }'
+     -H "Accept: application/vnd.github.everest-preview+json" \
+     -H "Content-Type: application/json" https://api.github.com/repos/elastio/packaging/dispatches \
+     --data '{ "event_type": "elastio-snap #'$GITHUB_RUN_NUMBER': '$GITHUB_EVENT_NAME' '$where_from' '$SOURCE_BRANCH'", "client_payload": { "branch": "'$SOURCE_BRANCH'" } }'

--- a/.github/scripts/set_env.sh
+++ b/.github/scripts/set_env.sh
@@ -5,8 +5,8 @@ dist_name=$(echo $DISTRO | grep -o -E '[a-z]+')
 dist_name=$(d=${dist_name^} && echo ${d//os/OS})
 dist_ver=$(echo $DISTRO | grep -o -E '[0-9]+')
 case $dist_name in
-  Debian|Ubuntu) pkg_type=deb ;;
-  *)             pkg_type=rpm ;;
+    Debian|Ubuntu) pkg_type=deb ;;
+    *)             pkg_type=rpm ;;
 esac
 runner_num=$(echo $GITHUB_WORKSPACE | grep -o -E '[0-9]+' | head -1)
 echo ::set-env name=PKG_TYPE::$pkg_type

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Make manifest
-        run: echo ${{env.GITHUB_RUN_NUMBER}} > latest
+        run: echo $GITHUB_RUN_NUMBER > latest && cat latest | grep -E '^[0-9]+$'
 
       - name: Upload manifest
         run: repobuild/upload.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - baremetal
 
     steps:
+      - name: Checkout sources 
+        uses: actions/checkout@v2
+
       - name: Make manifest
         run: echo ${{env.GITHUB_RUN_NUMBER}} > latest
 
@@ -88,6 +91,9 @@ jobs:
       - baremetal
 
     steps:
+      - name: Checkout sources 
+        uses: actions/checkout@v2
+
       - name: Dispatch packaging repo
         env:
           REPO_HOOK_TOKEN: ${{ secrets.REPO_HOOK_TOKEN }}


### PR DESCRIPTION
The new failures are appeared after the previous fix.
This time upload script gets a wrong argument (target path, witch contains
branch name).
Example: https://github.com/elastio/elastio-snap/runs/1180619657

That was just because checkout sources at the beginning of each job was
forgotten. It completely explains wrong behaviour, described in the
https://github.com/elastio/elastio-snap/issues/45

Finally resolves #45