### PR TITLE
Add module build and tests to the build steps on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
           debian8, debian9, debian10,
           centos7, centos8,
           amazon2,
-          fedora31, fedora32
+          # TODO: Bring back Fedora when issue https://github.com/elastio/elastio-snap/issues/44 is fixed
+          # fedora31, fedora32
         ]
         arch: [ amd64 ]
 
@@ -52,6 +53,24 @@ jobs:
       - name: Collect artifacts
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'repobuild/collect_artifacts.sh'
         working-directory: ${{env.BOX_DIR}}
+
+      - name: Build kernel module
+        run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'make'
+        working-directory: ${{env.BOX_DIR}}
+
+      - name: Install kernel module
+        run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'sudo make install'
+        working-directory: ${{env.BOX_DIR}}
+
+      - name: Run tests
+        # TODO: Bring back tests for Debian 9 when issue https://github.com/elastio/elastio-snap/issues/50
+        # is fixed
+        if: ${{ matrix.distro != 'debian9' }}
+        run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'cd tests && sudo ./elio-test.sh'
+        working-directory: ${{env.BOX_DIR}}
+        # For now tests are taking 10-20 seconds. But they can hang.
+        # 5 minutes seems to be reasonable timeout.
+        timeout-minutes: 5
 
       - name: Upload artifacts
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'AWS_SECRET_ACCESS_KEY='"'$AWS_SECRET_ACCESS_KEY'"' repobuild/upload.sh

--- a/tests/elio-test.sh
+++ b/tests/elio-test.sh
@@ -6,6 +6,20 @@
 # Additional contributions by Elastio Software, Inc are Copyright (C) 2020 Elastio Software Inc.
 #
 
+if [ "$EUID" -ne 0 ]; then
+    echo "Run as sudo or root."
+    exit 1
+fi
+
+packman="apt-get"
+which yum >/dev/null && packman=yum
+which pip3 >/dev/null || $packman install -y python3-pip
+
+if ! pip3 list | grep -q cffi ; then
+    echo "Python module CFFI is not installed. Installing it..."
+    pip3 install cffi
+fi
+
 echo
 echo "elastio-snap: $(git rev-parse --short HEAD)"
 echo "kernel: $(uname -r)"


### PR DESCRIPTION
No need to upload packages in case if module is not installable.
The appropriate step has been added to the build. It makes and installs
the kernel module.
Then it runs Python tests.

Closes #30