### PR TITLE
Get rid of hardcoded 'loop0' device in tests

### DIFF
--- a/tests/devicetestcase.py
+++ b/tests/devicetestcase.py
@@ -11,20 +11,23 @@ import unittest
 import kmod
 import util
 
+from random import randint
 
 @unittest.skipUnless(os.geteuid() == 0, "Must be run as root")
 class DeviceTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.backing_store = "/tmp/disk.img"
-        cls.device = "/dev/loop0"
-        cls.mount = "/tmp/elastio-snap"
+        cls.minor = randint(0, 23)
+        r =  randint(0, 999)
+        cls.backing_store = "/tmp/disk_{0:03d}.img".format(r)
+        cls.mount = "/tmp/elastio-snap_{0:03d}".format(r)
 
         cls.kmod = kmod.Module("../src/elastio-snap.ko")
         cls.kmod.load(debug=1)
 
         util.dd("/dev/zero", cls.backing_store, 256, bs="1M")
-        util.loop_create(cls.device, cls.backing_store)
+        cls.device = util.loop_create(cls.backing_store)
+
         util.mkfs(cls.device)
         os.makedirs(cls.mount, exist_ok=True)
         util.mount(cls.device, cls.mount)

--- a/tests/test_destroy.py
+++ b/tests/test_destroy.py
@@ -17,12 +17,9 @@ from devicetestcase import DeviceTestCase
 
 class TestDestroy(DeviceTestCase):
     def setUp(self):
-        self.device = "/dev/loop0"
-        self.mount = "/tmp/elastio-snap"
         self.cow_file = "cow.snap"
         self.cow_full_path = "{}/{}".format(self.mount, self.cow_file)
         self.cow_reload_path = "/{}".format(self.cow_file)
-        self.minor = 1
         self.snap_device = "/dev/elastio-snap{}".format(self.minor)
 
     def test_destroy_nonexistent_device(self):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -17,11 +17,8 @@ from devicetestcase import DeviceTestCase
 
 class TestSetup(DeviceTestCase):
     def setUp(self):
-        self.device = "/dev/loop0"
-        self.mount = "/tmp/elastio-snap"
         self.cow_file = "cow.snap"
         self.cow_full_path = "{}/{}".format(self.mount, self.cow_file)
-        self.minor = 1
         self.snap_device = "/dev/elastio-snap{}".format(self.minor)
 
     def test_setup_invalid_minor(self):

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -17,11 +17,8 @@ from devicetestcase import DeviceTestCase
 
 class TestSnapshot(DeviceTestCase):
     def setUp(self):
-        self.device = "/dev/loop0"
-        self.mount = "/tmp/elastio-snap"
         self.cow_file = "cow.snap"
         self.cow_full_path = "{}/{}".format(self.mount, self.cow_file)
-        self.minor = 1
 
         self.snap_mount = "/mnt"
         self.snap_device = "/dev/elastio-snap{}".format(self.minor)

--- a/tests/test_transition_incremental.py
+++ b/tests/test_transition_incremental.py
@@ -17,11 +17,8 @@ from devicetestcase import DeviceTestCase
 
 class TestTransitionToIncremental(DeviceTestCase):
     def setUp(self):
-        self.device = "/dev/loop0"
-        self.mount = "/tmp/elastio-snap"
         self.cow_file = "cow.snap"
         self.cow_full_path = "{}/{}".format(self.mount, self.cow_file)
-        self.minor = 1
 
     def test_transition_nonexistent_snapshot(self):
         self.assertIsNone(elastio_snap.info(self.minor))

--- a/tests/util.py
+++ b/tests/util.py
@@ -45,9 +45,9 @@ def settle(timeout=20):
     subprocess.check_call(cmd, timeout=(timeout + 10))
 
 
-def loop_create(loop, path):
-    cmd = ["losetup", loop, path]
-    subprocess.check_call(cmd, timeout=10)
+def loop_create(path):
+    cmd = ["losetup", "--find", "--show", path]
+    return subprocess.check_output(cmd, timeout=10).rstrip().decode("utf-8")
 
 
 def loop_destroy(loop):


### PR DESCRIPTION
Now tests are use first available loop device.

Also added random number to the hardcoded file name for the loop device
and mountpoint. Maybe some time later some tests will run in
simultaneously.
And minor is in the available range of 0..23.

Closes #52