### PR TITLE
Remove deprecated set-env from ci.yml

### DIFF
--- a/.github/scripts/set_env.sh
+++ b/.github/scripts/set_env.sh
@@ -1,5 +1,4 @@
 set -x
-echo ::set-env name=SOURCE_BRANCH::$(.github/scripts/detect_branch.sh)
 
 dist_name=$(echo $DISTRO | grep -o -E '[a-z]+')
 dist_name=$(d=${dist_name^} && echo ${d//os/OS})
@@ -8,11 +7,15 @@ case $dist_name in
     Debian|Ubuntu) pkg_type=deb ;;
     *)             pkg_type=rpm ;;
 esac
+
 runner_num=$(echo $GITHUB_WORKSPACE | grep -o -E '[0-9]+' | head -1)
-echo ::set-env name=PKG_TYPE::$pkg_type
-echo ::set-env name=DIST_NAME::$dist_name
-echo ::set-env name=DIST_VER::$dist_ver
-echo ::set-env name=RUNNER_NUM::$runner_num
-echo ::set-env name=BOX_DIR::".github/buildbox"
-echo ::set-env name=BOX_NAME::$(echo $DISTRO-$ARCH-build)
-echo ::set-env name=INSTANCE_NAME::$(echo $DISTRO-$ARCH-build-$runner_num)
+source_branch=$(.github/scripts/detect_branch.sh)
+
+echo "SOURCE_BRANCH=$source_branch"                     >> $GITHUB_ENV
+echo "PKG_TYPE=$pkg_type"                               >> $GITHUB_ENV
+echo "DIST_NAME=$dist_name"                             >> $GITHUB_ENV
+echo "DIST_VER=$dist_ver"                               >> $GITHUB_ENV
+echo "RUNNER_NUM=$runner_num"                           >> $GITHUB_ENV
+echo "BOX_DIR=.github/buildbox"                         >> $GITHUB_ENV
+echo "BOX_NAME=$DISTRO-$ARCH-build"                     >> $GITHUB_ENV
+echo "INSTANCE_NAME=$DISTRO-$ARCH-build-$runner_num"    >> $GITHUB_ENV


### PR DESCRIPTION
It's replaced in accordance to the new approach how to set build env vars, described here
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

Closes https://github.com/elastio/packaging/issues/31