### PR TITLE
Update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,6 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
 
       - name: Run tests
-        # TODO: Bring back tests for Debian 9 when issue https://github.com/elastio/elastio-snap/issues/50
-        # is fixed
-        if: ${{ matrix.distro != 'debian9' }}
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'cd tests && sudo ./elio-test.sh'
         working-directory: ${{env.BOX_DIR}}
         # For now tests are taking 10-20 seconds. But they can hang.

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -1,5 +1,5 @@
 # debbuild doesn't define _usrsrc yet
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 %global _usrsrc %{_prefix}/src
 %endif
 
@@ -32,14 +32,14 @@
 
 # On Debian/Ubuntu systems, /bin/sh usually points to /bin/dash,
 # and we need it to be /bin/bash, so we set it here.
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 %global _buildshell /bin/bash
 %global ___build_args %{nil}
 %endif
 
 # Set up the correct DKMS module name, per Debian convention for Debian/Ubuntu,
 # and use the other name, per convention on all other distros.
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 %global dkmsname %{name}-dkms
 %else
 %global dkmsname dkms-%{name}
@@ -47,7 +47,7 @@
 
 # SUSE Linux does not define the dist tag,
 # so we must define it manually
-%if %{_vendor} == "suse"
+%if "%{_vendor}" == "suse"
 %global dist .suse%{?suse_version}
 
 # If SLE 11, redefine it to use SLE prefix
@@ -75,12 +75,12 @@
 
 %endif
 
-%if %{_vendor} != "debbuild"
+%if "%{_vendor}" != "debbuild"
 %global rpm_dkms_opt 1
 %endif
 
 # Set the libdir correctly for Debian/Ubuntu systems
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 %global _libdir %{_prefix}/lib/%(%{__dpkg_architecture} -qDEB_HOST_MULTIARCH)
 %endif
 
@@ -88,7 +88,7 @@
 %global libprefix libelastio-snap
 %global libsover 1
 
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 %global devsuffix dev
 %else
 %global devsuffix devel
@@ -111,7 +111,7 @@ Version:         0.10.13
 Release:         1%{?dist}
 Summary:         Kernel module and utilities for enabling low-level live backups
 Vendor:          Elastio Software, Inc.
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 Packager:        Elastio Software Packagers <packages@elastio.com>
 Group:           kernel
 License:         GPL-2.0
@@ -145,7 +145,7 @@ live image snapshots through block devices.
 
 %package -n %{libname}
 Summary:         Library for communicating with %{name} kernel module
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 Group:           libs
 License:         LGPL-2.1+
 %else
@@ -164,7 +164,7 @@ The library for communicating with the %{name} kernel module.
 
 %package -n %{devname}
 Summary:         Files for developing applications to use %{name}.
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 Group:           libdevel
 License:         LGPL-2.1+
 %else
@@ -185,7 +185,7 @@ to use %{name}.
 
 %package utils
 Summary:         Utilities for using %{name} kernel module
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 Group:           admin
 %else
 %if 0%{?suse_version}
@@ -206,7 +206,7 @@ Utilities for %{name} to use the kernel module.
 
 %package -n %{dkmsname}
 Summary:         Kernel module source for %{name} managed by DKMS
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 Group:           kernel
 %else
 %if 0%{?suse_version}
@@ -241,7 +241,7 @@ Requires:        perl
 # Dependencies for actually building the kmod
 Requires:        make
 
-%if %{_vendor} != "debbuild"
+%if "%{_vendor}" != "debbuild"
 %if 0%{?rhel} >= 6 || 0%{?suse_version} >= 1210 || 0%{?fedora}
 # With RPM 4.9.0 and newer, it's possible to give transaction
 # hints to ensure some kind of ordering for transactions using
@@ -314,7 +314,7 @@ sed -e "s:@prefix@:%{_prefix}:g" \
 
 
 # Generate symbols for library package (Debian/Ubuntu only)
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 mkdir -p %{buildroot}/%{libname}/DEBIAN
 dpkg-gensymbols -P%{buildroot} -p%{libname} -v%{version}-%{release} -e%{buildroot}%{_libdir}/%{libprefix}.so.%{?!libsover:0}%{?libsover} -e%{buildroot}%{_libdir}/%{libprefix}.so.%{?!libsover:0}%{?libsover}.* -O%{buildroot}/%{libname}/DEBIAN/symbols
 %endif
@@ -388,7 +388,7 @@ find %{buildroot} -name "*.git*" -print0 | xargs -0 rm -rfv
 
 %preun -n %{dkmsname}
 
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then
 %else
 if [ $1 -eq 0 ]; then
@@ -408,7 +408,7 @@ fi
 
 rmmod %{name} &> /dev/null
 
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 if [ "$1" = "configure" ]; then
 %else
 if [ "$1" -ge "1" ]; then
@@ -499,11 +499,11 @@ rm -rf %{buildroot}
 %endif
 %endif
 %doc README.md doc/STRUCTURE.md
-%if %{_vendor} == "redhat"
+%if "%{_vendor}" == "redhat"
 %{!?_licensedir:%global license %doc}
 %license COPYING* LICENSING.md
 %else
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 %license dist/copyright
 %else
 %doc COPYING* LICENSING.md
@@ -515,11 +515,11 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 %endif
 %{_libdir}/libelastio-snap.so.%{libsover}
-%if %{_vendor} == "redhat"
+%if "%{_vendor}" == "redhat"
 %{!?_licensedir:%global license %doc}
 %license COPYING* LICENSING.md
 %else
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 %license dist/copyright
 %else
 %doc COPYING* LICENSING.md
@@ -533,11 +533,11 @@ rm -rf %{buildroot}
 %{_libdir}/libelastio-snap.so
 %{_libdir}/pkgconfig/libelastio-snap.pc
 %{_includedir}/elastio-snap/
-%if %{_vendor} == "redhat"
+%if "%{_vendor}" == "redhat"
 %{!?_licensedir:%global license %doc}
 %license COPYING* LICENSING.md
 %else
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 %license dist/copyright
 %else
 %doc COPYING* LICENSING.md
@@ -570,11 +570,11 @@ rm -rf %{buildroot}
 %{_sysconfdir}/kernel/postinst.d/50-elastio-snap
 %endif
 %doc README.md
-%if %{_vendor} == "redhat"
+%if "%{_vendor}" == "redhat"
 %{!?_licensedir:%global license %doc}
 %license COPYING* LICENSING.md
 %else
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 %license dist/copyright
 %else
 %doc COPYING* LICENSING.md

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -34,7 +34,6 @@
 # and we need it to be /bin/bash, so we set it here.
 %if "%{_vendor}" == "debbuild"
 %global _buildshell /bin/bash
-%global ___build_args %{nil}
 %endif
 
 # Set up the correct DKMS module name, per Debian convention for Debian/Ubuntu,
@@ -395,7 +394,7 @@ if [ $1 -eq 0 ]; then
 %endif
     lsmod | grep %{name} >& /dev/null
     if [ $? -eq 0 ]; then
-        modprobe -r %{name}
+        modprobe -r %{name} || :
     fi
 fi
 
@@ -406,7 +405,7 @@ fi
 
 %post -n %{dkmsname}
 
-rmmod %{name} &> /dev/null
+rmmod %{name} &> /dev/null || :
 
 %if "%{_vendor}" == "debbuild"
 if [ "$1" = "configure" ]; then
@@ -425,15 +424,15 @@ fi
 # Generate initramfs
 if type "dracut" &> /dev/null; then
     echo "Configuring dracut, please wait..."
-    dracut -f
+    dracut -f || :
 elif type "mkinitrd" &> /dev/null; then
     echo "Configuring initrd, please wait..."
-    mkinitrd
+    mkinitrd || :
 elif type "update-initramfs" &> /dev/null; then
     echo "Configuring initramfs, please wait..."
-    update-initramfs -u
+    update-initramfs -u || :
 fi
-sleep 1
+sleep 1 || :
 %endif
 
 
@@ -447,13 +446,13 @@ if [ $1 -eq 0 ]; then
 
         if type "dracut" &> /dev/null; then
                 echo "Configuring dracut, please wait..."
-                dracut -f
+                dracut -f || :
         elif type "mkinitrd" &> /dev/null; then
                 echo "Configuring initrd, please wait..."
-                mkinitrd
+                mkinitrd || :
         elif type "update-initramfs" &> /dev/null; then
                 echo "Configuring initramfs, please wait..."
-                update-initramfs -u
+                update-initramfs -u || :
         fi
 fi
 %endif

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -106,7 +106,7 @@
 
 
 Name:            elastio-snap
-Version:         0.10.13
+Version:         0.10.14
 Release:         1%{?dist}
 Summary:         Kernel module and utilities for enabling low-level live backups
 Vendor:          Elastio Software, Inc.
@@ -582,6 +582,12 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Fri Oct 16 2020 Dakota Williams <drwilliams@datto.com> - 0.10.14
+- Fix for error message during kernel module installation
+- Fix for userspace pointer leak
+- Fix for deb9 SCSI drives
+- Fix for bare words comparison in rpm spec
+
 * Wed Feb 5 2020 Dakota Williams <drwilliams@datto.com> - 0.10.13
 - Fix for -Wframe-larger-than
 

--- a/src/elastio-snap.h
+++ b/src/elastio-snap.h
@@ -15,7 +15,7 @@
 #include <linux/ioctl.h>
 #include <linux/limits.h>
 
-#define ELASTIO_SNAP_VERSION "0.10.13"
+#define ELASTIO_SNAP_VERSION "0.10.14"
 #define ELASTIO_IOCTL_MAGIC 'A' // 0x41
 
 struct setup_params{

--- a/tests/elio-test.sh
+++ b/tests/elio-test.sh
@@ -15,7 +15,7 @@ packman="apt-get"
 which yum >/dev/null && packman=yum
 which pip3 >/dev/null || $packman install -y python3-pip
 
-if ! pip3 list | grep -q cffi ; then
+if ! pip3 list --format=legacy 2>/dev/null | grep -q cffi ; then
     echo "Python module CFFI is not installed. Installing it..."
     pip3 install cffi
 fi


### PR DESCRIPTION
There are fixes for:
- kernel 4.9 and SCSI driver conflict.
Interesting facts about this fix (7ea4ee4):
   - It also fixes problem of the kernel module usage with the loop devices on Debian 9 (kernel 4.9.0-13) and resolves issue #50.  
   - This fix has been reverted in upstream https://github.com/datto/dattobd/commit/275ac8bbce578a09d23961bbd675a7c05176a5b6
- ~multipage bio requests~
I was intended to merge it too, but this commit https://github.com/datto/dattobd/commit/9a15da2c9216b861a635101071e7a08e07af20bf breaks tests https://github.com/elastio/elastio-snap/runs/1444115356
Also it was reverted in upstream https://github.com/datto/dattobd/commit/bb24cbca415e23abad9a2776a243930ad2ee2594
So, finally it's removed from this PR.
- package build with new RPM version (18a62c4 and 5fa6d6e).

Also in addition to the merge from upstream. here are enabled tests for Debian 9 and suppressed pip3's error noise from the tests output.

Resolves #50.