### PR TITLE
Fix fs corrupt on XFS v5

### DIFF
--- a/src/configure-tests/feature-tests/freeze_super.c
+++ b/src/configure-tests/feature-tests/freeze_super.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+// 2.6.34 < kernel_version
+
+#include "includes.h"
+
+static inline void dummy(void){
+	struct super_block sb;
+	int res;
+
+	res = freeze_super(&sb);
+	res = thaw_super(&sb);
+}


### PR DESCRIPTION
freeze_super do much more work comparetively with the freeze_bdev. It
syncs filesystem and waits for pending writes.
In case of XFS v5 freeze_bdev doesn't freeze super.
Used freeze_super instead of freeze_bdev for any fs and all kernels,
where this function is present.

Fixes #59