### PR TITLE
Fix '%preun' action for the kenel module package

### DIFF
--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -392,14 +392,12 @@ if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then
 %else
 if [ $1 -eq 0 ]; then
 %endif
-    lsmod | grep %{name} >& /dev/null
-    if [ $? -eq 0 ]; then
+    if lsmod | grep -q $(echo %{name} | tr '-' '_') ; then
         modprobe -r %{name} || :
     fi
 fi
 
-dkms status -m %{name} -v %{version} | grep %{name} >& /dev/null
-if [ $? -eq 0 ]; then
+if dkms status -m %{name} -v %{version} | grep -q %{name} ; then
     dkms remove -m %{name} -v %{version} --all %{?rpm_dkms_opt:--rpm_safe_upgrade}
 fi
 


### PR DESCRIPTION
There were few problems with the kernel module package uninstall.
Interesting, but it was reproduced just with the deb packages.
So, uninstall was unsuccessful in these cases:
- `lsmod | grep elastio-snap` returns nothing. The loaded module name is
  always with the replaced hyphen with underscore. Now we are greping an
  appropriate string.
- in case if `elastio_snap` kernel module was already unloaded by
  `rmmod` command.
- in case if `elastio-snap` kernel module files were alredy removed by
  `dkms`.

Resolves #66