### PR TITLE
Load module after install on Debian/Ubuntu

### DIFF
--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -411,9 +411,11 @@ if [ "$1" = "configure" ]; then
 if [ "$1" -ge "1" ]; then
 %endif
     if [ -f /usr/lib/dkms/common.postinst ]; then
-        /usr/lib/dkms/common.postinst %{name} %{version}
-        exit $?
+        /usr/lib/dkms/common.postinst %{name} %{version} || exit $?
     fi
+%if "%{_vendor}" == "debbuild"
+    modinfo %{name} &> /dev/null && modprobe %{name} || :
+%endif
 fi
 
 


### PR DESCRIPTION
Interestingly, CentOS 7, Ubuntu 20.04 have the same DKMS 2.8 version.
Debian 10 has older DKMS 2.6.
DKMS from CentOS restarts systemd-modules-load service
after module installation and depmod operation. DKMS from
Debian/Ubuntu doesn't.
And the 'POST_INSTALL' in the dkms.conf to run a script using
`modprobe` doesn't help either, because it's called after installing
the module, but before calling `depmod`.
Thus, the only way to load the module after installation is to
explicitely call `modprobe` on the `%post`-install action.

Resolves #68