### PR TITLE
Linux kernel 5.8 support

### DIFF
--- a/.github/scripts/set_env.sh
+++ b/.github/scripts/set_env.sh
@@ -19,3 +19,4 @@ echo "RUNNER_NUM=$runner_num"                           >> $GITHUB_ENV
 echo "BOX_DIR=.github/buildbox"                         >> $GITHUB_ENV
 echo "BOX_NAME=$DISTRO-$ARCH-build"                     >> $GITHUB_ENV
 echo "INSTANCE_NAME=$DISTRO-$ARCH-build-$runner_num"    >> $GITHUB_ENV
+echo "TEST_IMAGE=$PWD/$DISTRO-test_image.qcow2"         >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 ---
 name: ci
-on: 
+on:
   - push
 
 env:
@@ -20,13 +20,16 @@ jobs:
           debian8, debian9, debian10,
           centos7, centos8,
           amazon2,
-          # TODO: Bring back Fedora when issue https://github.com/elastio/elastio-snap/issues/44 is fixed
-          # fedora31, fedora32
+          fedora31
+          # TODO: Bring back
+          # - Fedora 32 when kernel 5.9  is supported (issue https://github.com/elastio/elastio-snap/issues/57 is fixed)
+          # - Fedora 33 when kernel 5.10 is supported.
+          # fedora32, fedora33
         ]
         arch: [ amd64 ]
 
     steps:
-      - name: Checkout sources 
+      - name: Checkout sources
         uses: actions/checkout@v2
 
       - name: Set ENV
@@ -62,12 +65,31 @@ jobs:
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'sudo make install'
         working-directory: ${{env.BOX_DIR}}
 
+        # NOTE: This special logic with the real block device instead of the loop device is used especially for Fedora 31
+        # due to ussie https://github.com/elastio/elastio-snap/issues/71. It can be simplified back after the issue is fixed.
+      - name: Attach external drive
+        if: ${{ matrix.distro == 'fedora31' }}
+        run: |
+          qemu-img create -f qcow2 ${TEST_IMAGE} 1G
+          virsh attach-disk --domain ${BOX_DIR##*/}_${INSTANCE_NAME} --source ${TEST_IMAGE} --target vdb --driver qemu --subdriver qcow2 --targetbus virtio
+          cd $BOX_DIR && vagrant ssh ${{env.INSTANCE_NAME}} -c 'echo -e "n\np\n\n\n\nw" | sudo fdisk /dev/vdb'
+
       - name: Run tests
-        run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'cd tests && sudo ./elio-test.sh'
+        run: |
+          [[ $INSTANCE_NAME == fedora31* ]] && device=/dev/vdb1
+          vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh $device"
         working-directory: ${{env.BOX_DIR}}
         # For now tests are taking 10-20 seconds. But they can hang.
         # 5 minutes seems to be reasonable timeout.
         timeout-minutes: 5
+
+      - name: Detach external drive
+        if: always()
+        run: |
+          if virsh domblklist ${BOX_DIR##*/}_${INSTANCE_NAME} --details | grep "file" | awk '{ print $NF }' | grep ${TEST_IMAGE} ; then
+              virsh detach-disk --domain ${BOX_DIR##*/}_${INSTANCE_NAME} ${TEST_IMAGE}
+          fi
+          rm -f ${TEST_IMAGE}
 
       - name: Upload artifacts
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'AWS_SECRET_ACCESS_KEY='"'$AWS_SECRET_ACCESS_KEY'"' repobuild/upload.sh
@@ -88,7 +110,7 @@ jobs:
       - baremetal
 
     steps:
-      - name: Checkout sources 
+      - name: Checkout sources
         uses: actions/checkout@v2
 
       - name: Make manifest
@@ -102,12 +124,12 @@ jobs:
 
   dispatch-packaging-repo:
     name: Trigger repo upload
-    needs: manifest 
+    needs: manifest
     runs-on:
       - baremetal
 
     steps:
-      - name: Checkout sources 
+      - name: Checkout sources
         uses: actions/checkout@v2
 
       - name: Dispatch packaging repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
 
         # NOTE: This special logic with the real block device instead of the loop device is used especially for Fedora 31
-        # due to ussie https://github.com/elastio/elastio-snap/issues/71. It can be simplified back after the issue is fixed.
+        # due to issue https://github.com/elastio/elastio-snap/issues/71. It can be simplified back after the issue is fixed.
       - name: Attach external drive
         if: ${{ matrix.distro == 'fedora31' }}
         run: |

--- a/tests/elio-test.sh
+++ b/tests/elio-test.sh
@@ -30,6 +30,13 @@ echo
 
 dmesg -c &> /dev/null
 >| dmesg.log
+
+[ ! -z "$1" ] && export TEST_DEVICE="$1"
+if ! lsblk $TEST_DEVICE >/dev/null 2>&1; then
+    echo "The script's argumet $TEST_DEVICE seems to be not a block device."
+    exit 1
+fi
+
 python3 -m unittest -v
 ret=$?
 dmesg > dmesg.log


### PR DESCRIPTION
- **Linux kernel 5.8 support**

A block device requests queue has a function 'make_request_fn' which is
used in the driver to send requests to the device underlyng to a
snapshot. Suddenly, starting from the kernel 5.8, this function has
become empty (NULL) in most cases.
Used call of the similar function 'blk_mq_make_request' in case if the
'make_request_fn' is not set. This call is wrapped into the
elastio_snap_null_mrf function with the memory barrier before call
blk_mq_make_request. Otherwise driver hangs on the snapshot destry
operation.

Resolves #44

Note: build of the driver on the Linux kernel 5.8 has been already fixed
in the #48, commit 96d63d.

- **Added possibility to use real block device in tests and enabled build and tests for Fedora 31**

Now name of the device can be specified to the tests/elio-test.sh
script as an argument.
This is useful in case of some issues related to the loop device.
Actually it's a workaround for the #71

