### PR TITLE
Fix tests on the loop dev on Linux 5.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,22 +65,22 @@ jobs:
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'sudo make install'
         working-directory: ${{env.BOX_DIR}}
 
-        # NOTE: This special logic with the real block device instead of the loop device is used especially for Fedora 31
-        # due to issue https://github.com/elastio/elastio-snap/issues/71. It can be simplified back after the issue is fixed.
-      - name: Attach external drive
-        if: ${{ matrix.distro == 'fedora31' }}
+      - name: Run tests (loop device)
+        run: vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh"
+        working-directory: ${{env.BOX_DIR}}
+        # For now tests are taking 10-20 seconds. But they can hang.
+        # 5 minutes seems to be reasonable timeout.
+        timeout-minutes: 5
+
+      - name: Attach qcow2 disk
         run: |
           qemu-img create -f qcow2 ${TEST_IMAGE} 1G
           virsh attach-disk --domain ${BOX_DIR##*/}_${INSTANCE_NAME} --source ${TEST_IMAGE} --target vdb --driver qemu --subdriver qcow2 --targetbus virtio
           cd $BOX_DIR && vagrant ssh ${{env.INSTANCE_NAME}} -c 'echo -e "n\np\n\n\n\nw" | sudo fdisk /dev/vdb'
 
-      - name: Run tests
-        run: |
-          [[ $INSTANCE_NAME == fedora31* ]] && device=/dev/vdb1
-          vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh $device"
+      - name: Run tests (qcow2 disk)
+        run: vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh /dev/vdb"
         working-directory: ${{env.BOX_DIR}}
-        # For now tests are taking 10-20 seconds. But they can hang.
-        # 5 minutes seems to be reasonable timeout.
         timeout-minutes: 5
 
       - name: Detach external drive

--- a/tests/devicetestcase.py
+++ b/tests/devicetestcase.py
@@ -26,7 +26,7 @@ class DeviceTestCase(unittest.TestCase):
         cls.kmod.load(debug=1)
         if os.getenv('TEST_DEVICE'):
             cls.device = os.getenv('TEST_DEVICE')
-            dev_size = int(subprocess.check_output("blockdev --getsize64 %s" % cls.device, shell=True, text=True))//1024**2
+            dev_size = int(subprocess.check_output("blockdev --getsize64 %s" % cls.device, shell=True))//1024**2
             util.dd("/dev/zero", cls.device, dev_size, bs="1M")
         else:
             cls.backing_store = "/tmp/disk_{0:03d}.img".format(r)


### PR DESCRIPTION
**Fix, part 1**

There was a failure like this:
`percpu ref (blk_queue_usage_counter_release) <= 0 (-149) after switching to atomic`
at the moment when test was trying to destroy a loop dev.

The queue's usage counter was not incremented each time when blk_mq_make_request
has been called. Fixed it by the manual increment, so it have to be >= 0 before
it's destroyed.
Interesting nuance that the issue is observed just on the loop devices,
but it seems to be not a loop dev specific.

**Fix, part 2**

elastio_snap_null_mrf function was mistakenly set to the original device after a
snapshot has been destroyed and tracking has been finished. Now it's set
back to the NULL.

Updated tests:
- Removed a "special case" in the tests for Fedora 31 with the Linux 5.8.
  Now each distro has 2 steps with the tests. Once tests are running at the
  loop device, 2nd time they are running at the qcow2 drive.
- Fixed tests with a dev as argument on the Python 3.6.

Resolves #71