### PR TITLE
Support Linux kernel 5.9 and 5.10

### DIFF
--- a/.github/buildbox/Vagrantfile
+++ b/.github/buildbox/Vagrantfile
@@ -32,17 +32,19 @@ ENV_VARS_SCRIPT
 DISTROS = [ "debian8", "debian9", "debian10", "amazon2", "centos6", "centos7", "centos8", "fedora31", "fedora32" ]
 
 # NOTE: This environment variable should be set to enable triggers of the type "action".
-# The actions are used to make a lock around Vagrant::Action::Builtin::BoxAdd to avoid 
+# The actions are used to make a lock around Vagrant::Action::Builtin::BoxAdd to avoid
 # a problem, when 2 instances of the same box are "uping" and downloading new box (or version) image.
 # Vagrant uses same temporary file for all concurrent downloads. As result, it's corrupted.
-# Setting it just for the 'vagrnat up'. 
+# Setting it just for the 'vagrnat up'.
 ENV['VAGRANT_EXPERIMENTAL']='typed_triggers' if ARGV.include?('up')
 
 Vagrant.configure("2") do |config|
 
   DISTROS.each do |distro|
     box = "#{distro}-amd64-build"
-    config.vm.define "#{box}-#{ENV['RUNNER_NUM']}", autostart: false do |b|
+    instance = "#{box}-#{ENV['RUNNER_NUM']}"
+    next if ARGV.include?('up') && ARGV.none?("#{instance}")
+    config.vm.define "#{instance}", autostart: false do |b|
       b.vm.box = "#{box}"
       b.vm.box_url = [ "https://s3.eu-central-1.wasabisys.com/blobs-wasabi.elastio.dev/devboxes/master/#{box}.json" ]
       b.vm.box_version = $box_version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,9 @@ jobs:
           debian8, debian9, debian10,
           centos7, centos8,
           amazon2,
-          fedora31
-          # TODO: Bring back
-          # - Fedora 32 when kernel 5.9  is supported (issue https://github.com/elastio/elastio-snap/issues/57 is fixed)
+          fedora31, fedora32
           # - Fedora 33 when kernel 5.10 is supported.
-          # fedora32, fedora33
+          # fedora33
         ]
         arch: [ amd64 ]
 
@@ -49,6 +47,18 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
         run: .github/scripts/start_box.sh
 
+      - name: Boot Fedora 32 into kernel 5.9
+        if: "${{ matrix.distro == 'fedora32' }}"
+        run: |
+          vagrant ssh ${{env.INSTANCE_NAME}} -c '
+            sudo yum localinstall -y https://kojipkgs.fedoraproject.org//packages/kernel/5.9.16/100.fc32/x86_64/kernel-core-5.9.16-100.fc32.x86_64.rpm
+            sudo yum localinstall -y https://kojipkgs.fedoraproject.org//packages/kernel/5.9.16/100.fc32/x86_64/kernel-modules-5.9.16-100.fc32.x86_64.rpm
+            sudo yum localinstall -y https://kojipkgs.fedoraproject.org//packages/kernel/5.9.16/100.fc32/x86_64/kernel-5.9.16-100.fc32.x86_64.rpm
+            sudo yum localinstall -y https://kojipkgs.fedoraproject.org//packages/kernel/5.9.16/100.fc32/x86_64/kernel-devel-5.9.16-100.fc32.x86_64.rpm
+            sudo reboot now' || true
+          sleep 5
+        working-directory: ${{env.BOX_DIR}}
+
       - name: Build packages
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'make ${PKG_TYPE}'
         working-directory: ${{env.BOX_DIR}}
@@ -58,7 +68,7 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
 
       - name: Build kernel module
-        run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'make'
+        run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'sudo make'
         working-directory: ${{env.BOX_DIR}}
 
       - name: Install kernel module
@@ -79,7 +89,7 @@ jobs:
           cd $BOX_DIR && vagrant ssh ${{env.INSTANCE_NAME}} -c 'echo -e "n\np\n\n\n\nw" | sudo fdisk /dev/vdb'
 
       - name: Run tests (qcow2 disk)
-        run: vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh /dev/vdb"
+        run: vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh /dev/vdb1"
         working-directory: ${{env.BOX_DIR}}
         timeout-minutes: 5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           centos7, centos8,
           amazon2,
           fedora31, fedora32
-          # - Fedora 33 when kernel 5.10 is supported.
+          # - Fedora 33 when kernel 5.11 is supported.
           # fedora33
         ]
         arch: [ amd64 ]

--- a/src/configure-tests/feature-tests/bdops_submit_bio.c
+++ b/src/configure-tests/feature-tests/bdops_submit_bio.c
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+// 5.9 <= kernel_version
+
+#include "includes.h"
+
+static blk_qc_t snap_submit_bio(struct bio *bio)
+{
+	return BLK_QC_T_NONE;
+}
+
+static inline void dummy(void){
+	struct bio b;
+	struct block_device_operations bdo = {
+		.submit_bio = snap_submit_bio,
+	};
+
+	bdo.submit_bio(&b);
+}

--- a/src/configure-tests/feature-tests/blk_mq_submit_bio.c
+++ b/src/configure-tests/feature-tests/blk_mq_submit_bio.c
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+#include "includes.h"
+
+static inline void dummy(void){
+	struct bio b;
+	blk_mq_submit_bio(&b);
+}

--- a/src/configure-tests/feature-tests/make_request_fn_in_queue.c
+++ b/src/configure-tests/feature-tests/make_request_fn_in_queue.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+// 5.8 <= kernel_version
+
+#include "includes.h"
+
+static inline void dummy(void){
+    make_request_fn *mk_rq_fn;
+	struct request_queue q = {
+		.make_request_fn = mk_rq_fn,
+	};
+	(void)q;
+}

--- a/src/configure-tests/feature-tests/thaw_bdev_int.c
+++ b/src/configure-tests/feature-tests/thaw_bdev_int.c
@@ -11,5 +11,5 @@ static inline void dummy(void){
 	struct block_device bd;
 	struct super_block sb;
 
-	if(thaw_bdev(&bd, &sb)) bd.bd_private = 0;
+	if(thaw_bdev(&bd, &sb)) bd.bd_disk = 0;
 }

--- a/src/configure-tests/symbol-tests
+++ b/src/configure-tests/symbol-tests
@@ -3,3 +3,4 @@ sys_umount
 sys_oldumount
 sys_call_table
 printk
+blk_mq_submit_bio


### PR DESCRIPTION
2 main problems are solved:
1. make_request_fn function in the queue has been replaced with the
   submit_bio function in the const struct block_device_operations.
   Now it's still replaced with the tracing_mrf with usage of the trick
   with disabling the memory read-only access protection during this
   operation.
2. This submit_bio function can be not set (NULL), as it was with the
   make_request_fn in the kernel 5.8. And the blk_mq_submit_bio (ex.
   blk_mq_make_request) helps again in this case. But it became not
   exported since 5.9.2. As result, it's called by the memory address

So, the fix is a bit fragile and hacky, but it resolves a problem of the
separate queue of the stolen bios and delays significant change in
the architecture of this driver.

Minor fixes for the kernel 5.9 support:
- Fixed thaw_bdev_int compat (bd_private is suddenly gone from the
  block_device structure).
- Added 3 new compats for the Linux 5.9:
    - make_request_fn is gone from the requet_queue
    - submit_bio is came to the block_device_operations
    - blk_mq_submit_bio for kernels 5.9.0 - 5.9.1
- Added symbol test for blk_mq_submit_bio in the kernel 5.9+

Enabled tests on Fedora 32 with the installed there kernel 5.9.16.

Resolves #57