### PR TITLE
Update from upstream

### DIFF
--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -106,7 +106,7 @@
 
 
 Name:            elastio-snap
-Version:         0.10.14
+Version:         0.10.15
 Release:         1%{?dist}
 Summary:         Kernel module and utilities for enabling low-level live backups
 Vendor:          Elastio Software, Inc.
@@ -256,7 +256,7 @@ Requires:        make
 # that DKMS will be able to successfully build against the new
 # kernel being installed.
 #
-# Upd: Left as it is for SLES and changed to Requires 
+# Upd: Left as it is for SLES and changed to Requires
 # statement for RHEL/CentOS and Fedora due to problem in DKMS.
 # It installs kernel-debug-devel instead of kernel-devel if no
 # kernel-devel package has been already installed. See more
@@ -582,6 +582,13 @@ rm -rf %{buildroot}
 
 
 %changelog
+
+* Fri May 21 2021 Eugene Kovalenko <ikovalenko@elastio.com> - 0.10.15
+- Update from upstream: Additional fix for multipage bios in kernel 5.4
+- Update from upstream: Corruption fix found on CentOS 6/7
+- Linux kernel 5.9 and 5.10 support
+- Linux kernel 5.8 support
+
 * Fri Oct 16 2020 Dakota Williams <drwilliams@datto.com> - 0.10.14
 - Fix for error message during kernel module installation
 - Fix for userspace pointer leak

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -3128,7 +3128,7 @@ retry:
 	if(ret) goto error;
 
 	//set pointers for read clone
-	ret = tp_add(tp, bio);
+	ret = tp_add(tp, new_bio);
 	if (ret) goto error;
 
 	atomic64_inc(&dev->sd_submitted_cnt);

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -815,9 +815,6 @@ static inline void elastio_snap_bio_copy_dev(struct bio *dst, struct bio *src){
 #define SECTOR_TO_BLOCK(sect) ((sect) / SECTORS_PER_BLOCK)
 #define BLOCK_TO_SECTOR(block) ((block) * SECTORS_PER_BLOCK)
 
-//maximum number of clones per traced bio
-#define MAX_CLONES_PER_BIO 10
-
 //macros for compilation
 #define MAYBE_UNUSED(x) (void)(x)
 
@@ -904,13 +901,19 @@ struct bio_sector_map{
 	struct bio *bio;
 	sector_t sect;
 	unsigned int size;
+	struct bio_sector_map *next;
+};
+
+struct bsector_list {
+	struct bio_sector_map* head;
+	struct bio_sector_map* tail;
 };
 
 struct tracing_params{
 	struct bio *orig_bio;
 	struct snap_device *dev;
 	atomic_t refs;
-	struct bio_sector_map bio_sects[MAX_CLONES_PER_BIO];
+	struct bsector_list bio_sects;
 };
 
 struct cow_section{
@@ -2513,6 +2516,8 @@ static int tp_alloc(struct snap_device *dev, struct bio *bio, struct tracing_par
 
 	tp->dev = dev;
 	tp->orig_bio = bio;
+	tp->bio_sects.head = NULL;
+	tp->bio_sects.tail = NULL;
 	atomic_set(&tp->refs, 1);
 
 	*tp_out = tp;
@@ -2526,10 +2531,42 @@ static void tp_get(struct tracing_params *tp){
 static void tp_put(struct tracing_params *tp){
 	//drop a reference to the tp
 	if(atomic_dec_and_test(&tp->refs)){
+		struct bio_sector_map *next, *curr = NULL;
+
 		//if there are no references left, its safe to release the orig_bio
 		bio_queue_add(&tp->dev->sd_orig_bios, tp->orig_bio);
+
+		// free nodes in the sector map list
+		for (curr = tp->bio_sects.head; curr != NULL; curr = next)
+		{
+			next = curr->next;
+			kfree(curr);
+		}
 		kfree(tp);
 	}
+}
+
+static int tp_add(struct tracing_params* tp, struct bio* bio) {
+	struct bio_sector_map* map;
+	map = kzalloc(1 * sizeof(struct bio_sector_map), GFP_NOIO);
+	if (!map) {
+		LOG_ERROR(-ENOMEM, "error allocating new bio_sector_map struct");
+		return -ENOMEM;
+	}
+
+	map->bio = bio;
+	map->sect = bio_sector(bio);
+	map->size = bio_size(bio);
+	map->next = NULL;
+	if (tp->bio_sects.head == NULL) {
+		tp->bio_sects.head = map;
+		tp->bio_sects.tail = map;
+	}
+	else {
+		tp->bio_sects.tail->next = map;
+		tp->bio_sects.tail = map;
+	}
+	return 0;
 }
 
 /****************************BIO HELPER FUNCTIONS*****************************/
@@ -2980,9 +3017,12 @@ static int inc_sset_thread(void *data){
 
 static void __on_bio_read_complete(struct bio *bio, int err){
 	int ret;
-	unsigned short i;
 	struct tracing_params *tp = bio->bi_private;
 	struct snap_device *dev = tp->dev;
+	struct bio_sector_map* map = NULL;
+#ifndef HAVE_BVEC_ITER
+	unsigned short i = 0;
+#endif
 
 	//check for read errors
 	if(err){
@@ -2995,19 +3035,13 @@ static void __on_bio_read_complete(struct bio *bio, int err){
 	elastio_snap_set_bio_ops(bio, REQ_OP_WRITE, 0);
 
 	//reset the bio iterator to its original state
-	for(i = 0; i < MAX_CLONES_PER_BIO && tp->bio_sects[i].bio != NULL; i++){
-		if(bio == tp->bio_sects[i].bio){
-			bio_sector(bio) = tp->bio_sects[i].sect - dev->sd_sect_off;
-			bio_size(bio) = tp->bio_sects[i].size;
+	for(map = tp->bio_sects.head; map != NULL && map->bio != NULL; map = map->next) {
+		if(bio == map->bio){
+			bio_sector(bio) = map->sect - dev->sd_sect_off;
+			bio_size(bio) = map->size;
 			bio_idx(bio) = 0;
 			break;
 		}
-	}
-
-	if(i == MAX_CLONES_PER_BIO){
-		ret = -EIO;
-		LOG_ERROR(ret, "clone not found in tp struct");
-		goto error;
 	}
 
 	/*
@@ -3074,7 +3108,7 @@ static int snap_trace_bio(struct snap_device *dev, struct bio *bio){
 	struct bio *new_bio = NULL;
 	struct tracing_params *tp = NULL;
 	sector_t start_sect, end_sect;
-	unsigned int bytes, pages, i = 0;
+	unsigned int bytes, pages;
 
 	//if we don't need to cow this bio just call the real mrf normally
 	if(!bio_needs_cow(bio, dev->sd_cow_inode)) return elastio_snap_call_mrf(dev->sd_orig_mrf, bio);
@@ -3093,16 +3127,9 @@ retry:
 	ret = bio_make_read_clone(dev_bioset(dev), tp, bio, start_sect, pages, &new_bio, &bytes);
 	if(ret) goto error;
 
-	//make sure we don't excede the max number of bio clones that tp can hold
-	if(i >= MAX_CLONES_PER_BIO){
-		ret = -EFAULT;
-		goto error;
-	}
-
 	//set pointers for read clone
-	tp->bio_sects[i].bio = new_bio;
-	tp->bio_sects[i].sect = bio_sector(new_bio);
-	tp->bio_sects[i].size = bio_size(new_bio);
+	ret = tp_add(tp, bio);
+	if (ret) goto error;
 
 	atomic64_inc(&dev->sd_submitted_cnt);
 	smp_wmb();
@@ -3114,7 +3141,6 @@ retry:
 	if(bytes / PAGE_SIZE < pages){
 		start_sect += bytes / SECTOR_SIZE;
 		pages -= bytes / PAGE_SIZE;
-		i++;
 		goto retry;
 	}
 

--- a/src/elastio-snap.h
+++ b/src/elastio-snap.h
@@ -15,7 +15,7 @@
 #include <linux/ioctl.h>
 #include <linux/limits.h>
 
-#define ELASTIO_SNAP_VERSION "0.10.14"
+#define ELASTIO_SNAP_VERSION "0.10.15"
 #define ELASTIO_IOCTL_MAGIC 'A' // 0x41
 
 struct setup_params{


### PR DESCRIPTION
Cherry-picked 2 useful fixes from the upstream:
- datto@9a15da2 Fix for the multipage bio in kernel 5.4+. Without this fix driver could overflow while tracking changed blocks and then fail with an error.
- datto@ed3f08fe Fix of the corruption, in the fix for the multipage bio.

Bumped driver version to the `0.10.15`.