### PR TITLE
Fix driver compilation with the kernel 5.11

### DIFF
--- a/.github/buildbox/Vagrantfile
+++ b/.github/buildbox/Vagrantfile
@@ -29,7 +29,11 @@ EOF
 chmod +x /etc/profile.d/set_build_env.sh
 ENV_VARS_SCRIPT
 
-DISTROS = [ "debian8", "debian9", "debian10", "amazon2", "centos6", "centos7", "centos8", "fedora31", "fedora32" ]
+DISTROS = [ "debian8", "debian9", "debian10",
+            "amazon2",
+            "centos6", "centos7", "centos8",
+            "fedora31", "fedora32",
+            "ubuntu2004" ]
 
 # NOTE: This environment variable should be set to enable triggers of the type "action".
 # The actions are used to make a lock around Vagrant::Action::Builtin::BoxAdd to avoid

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,10 @@ jobs:
           debian8, debian9, debian10,
           centos7, centos8,
           amazon2,
-          fedora31, fedora32
-          # - Fedora 33 when kernel 5.11 is supported.
-          # fedora33
+          fedora31, fedora32,
+          # - Uncomment Fedora 33 when kernel 5.12 is supported.
+          # fedora33,
+          ubuntu2004
         ]
         arch: [ amd64 ]
 

--- a/repobuild/collect_artifacts.sh
+++ b/repobuild/collect_artifacts.sh
@@ -11,10 +11,6 @@ declare -A POOLS
 POOLS[rpm]="x86_64/Packages"
 POOLS[deb]="pool"
 
-# system-release should be last, it's present on all rpm systems
-# and it's used here for amazon linux detection
-declare -a RELEASE_FILES=("centos-release" "fedora-release" "debian_version" "system-release")
-
 # Make 'info' file with the artifacts details
 make_info () {
 BUILD_NUMBER='local_build'
@@ -24,8 +20,8 @@ BUILD_NUMBER='local_build'
 SOURCE_BRANCH=`git rev-parse --abbrev-ref HEAD`
 COMMIT_SHA=`git rev-parse --short HEAD`
 
-mkdir -p $out/Debian
-cat > $out/Debian/elastio-snap.info << INFO
+mkdir -p $out/$dist_name
+cat > $out/$dist_name/elastio-snap.info << INFO
 Branch:     $SOURCE_BRANCH
 Rev:        $COMMIT_SHA
 Version:    `grep Version: $dir/../dist/elastio-snap.spec | awk '{print $NF}'`
@@ -33,24 +29,24 @@ Build:      $BUILD_NUMBER
 INFO
 }
 
-# Expected dist_name-s: Amazon CentOS Fedora
-dist_name=`cat /etc/system-release 2>/dev/null | cut -d' ' -f1`
-dist_ver=
-pkg_type=rpm
-for file in "${RELEASE_FILES[@]}"; do
-    if [ -f "/etc/$file" ]; then
-        # Expected dist_name-s: Debian CentOS Fedora
-        [ -z "$dist_name" ] && dist_name=`d=${file^} && echo ${d//os/OS} | cut -d'-' -f1 | cut -d'_' -f1`
-        dist_ver=`cat /etc/$file | tr -cd '[0-9.]' | cut -d'.' -f1`
-        [ "$file" == "debian_version" ] && pkg_type="deb" && make_info
-        break
-    fi
-done
+if `which apt-get >/dev/null 2>&1` ; then
+    dist_ver=$(grep VERSION_ID /etc/os-release | tr -cd '[0-9]')
+    dist_name=$(grep '^ID=' /etc/os-release | cut -d'=' -f2)
+    dist_name=${dist_name^}
+    pkg_type="deb"
+elif `which yum >/dev/null 2>&1` ; then
+    dist_ver=$(cat /etc/system-release 2>/dev/null | tr -cd '[0-9.]' | cut -d'.' -f1)
+    # Expected dist_name-s: Amazon CentOS Fedora
+    dist_name=$(cat /etc/system-release 2>/dev/null | cut -d' ' -f1)
+    pkg_type="rpm"
+fi
 
 if [ -z $dist_ver ] || [ -z $dist_name ]; then
     echo "Unknown Linux distro"
     exit 1
 fi
+
+[ "$dist_name" = "Debian" ] && make_info
 
 pool=$out/$dist_name/$dist_ver/${POOLS[$pkg_type]}
 copy_dirs=(${COPY_DIRS[$pkg_type]})

--- a/src/configure-tests/feature-tests/__dentry_path.c
+++ b/src/configure-tests/feature-tests/__dentry_path.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	char *c = NULL;

--- a/src/configure-tests/feature-tests/bd_super.c
+++ b/src/configure-tests/feature-tests/bd_super.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct block_device bd;

--- a/src/configure-tests/feature-tests/bdev_is_partition.c
+++ b/src/configure-tests/feature-tests/bdev_is_partition.c
@@ -8,6 +8,6 @@
 MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
-	struct bio b;
-	blk_mq_submit_bio(&b);
+	struct block_device bdev;
+	bdev_is_partition(&bdev);
 }

--- a/src/configure-tests/feature-tests/bdev_nr_sectors.c
+++ b/src/configure-tests/feature-tests/bdev_nr_sectors.c
@@ -8,6 +8,7 @@
 MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
-	struct bio b;
-	blk_mq_submit_bio(&b);
+	struct block_device bdev;
+	sector_t sect;
+	sect = bdev_nr_sectors(&bdev);
 }

--- a/src/configure-tests/feature-tests/bdev_stack_limits.c
+++ b/src/configure-tests/feature-tests/bdev_stack_limits.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct queue_limits *t;

--- a/src/configure-tests/feature-tests/bdops_open_inode.c
+++ b/src/configure-tests/feature-tests/bdops_open_inode.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static int snap_open(struct inode *inode, struct file *filp){
 	return 0;

--- a/src/configure-tests/feature-tests/bdops_open_int.c
+++ b/src/configure-tests/feature-tests/bdops_open_int.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static int snap_open(struct block_device *bdev, fmode_t mode){
 	return 0;

--- a/src/configure-tests/feature-tests/bdops_submit_bio.c
+++ b/src/configure-tests/feature-tests/bdops_submit_bio.c
@@ -7,6 +7,7 @@
 // 5.9 <= kernel_version
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static blk_qc_t snap_submit_bio(struct bio *bio)
 {

--- a/src/configure-tests/feature-tests/bio_bi_bdev.c
+++ b/src/configure-tests/feature-tests/bio_bi_bdev.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct bio bio;

--- a/src/configure-tests/feature-tests/bio_bi_pool.c
+++ b/src/configure-tests/feature-tests/bio_bi_pool.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct bio bio;

--- a/src/configure-tests/feature-tests/bio_bi_remaining.c
+++ b/src/configure-tests/feature-tests/bio_bi_remaining.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct bio b;

--- a/src/configure-tests/feature-tests/bio_endio_1.c
+++ b/src/configure-tests/feature-tests/bio_endio_1.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	bio_endio(NULL);

--- a/src/configure-tests/feature-tests/bio_endio_int.c
+++ b/src/configure-tests/feature-tests/bio_endio_int.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static int dummy_endio(struct bio *bio, unsigned int bytes, int err){
 	return 0;

--- a/src/configure-tests/feature-tests/bio_list.c
+++ b/src/configure-tests/feature-tests/bio_list.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct bio_list bl;

--- a/src/configure-tests/feature-tests/bioset_create_3.c
+++ b/src/configure-tests/feature-tests/bioset_create_3.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct bio_set *bs;

--- a/src/configure-tests/feature-tests/bioset_init.c
+++ b/src/configure-tests/feature-tests/bioset_init.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct bio_set bs;

--- a/src/configure-tests/feature-tests/bioset_need_bvecs_flag.c
+++ b/src/configure-tests/feature-tests/bioset_need_bvecs_flag.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	int flags = BIOSET_NEED_BVECS;

--- a/src/configure-tests/feature-tests/blk_alloc_queue_gfp_t.c
+++ b/src/configure-tests/feature-tests/blk_alloc_queue_gfp_t.c
@@ -7,6 +7,7 @@
 // 2.6.23 <= kernel_version < 5.7
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
     struct request_queue *queue = blk_alloc_queue(GFP_KERNEL);

--- a/src/configure-tests/feature-tests/blk_alloc_queue_mk_req_fn_node_id.c
+++ b/src/configure-tests/feature-tests/blk_alloc_queue_mk_req_fn_node_id.c
@@ -7,6 +7,7 @@
 // 5.7 <= kernel_version
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
     make_request_fn *mk_rq_fn;

--- a/src/configure-tests/feature-tests/blk_set_default_limits.c
+++ b/src/configure-tests/feature-tests/blk_set_default_limits.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct queue_limits *l = NULL;

--- a/src/configure-tests/feature-tests/blk_set_stacking_limits.c
+++ b/src/configure-tests/feature-tests/blk_set_stacking_limits.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct queue_limits *l = NULL;

--- a/src/configure-tests/feature-tests/blk_status_t.c
+++ b/src/configure-tests/feature-tests/blk_status_t.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	blk_status_t b = BLK_STS_OK;

--- a/src/configure-tests/feature-tests/blkdev_get_by_path.c
+++ b/src/configure-tests/feature-tests/blkdev_get_by_path.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct block_device *bd = blkdev_get_by_path("path", FMODE_READ, NULL);

--- a/src/configure-tests/feature-tests/blkdev_put_1.c
+++ b/src/configure-tests/feature-tests/blkdev_put_1.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct block_device bd;

--- a/src/configure-tests/feature-tests/bvec_iter.c
+++ b/src/configure-tests/feature-tests/bvec_iter.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct bvec_iter iter;

--- a/src/configure-tests/feature-tests/bvec_merge_data.c
+++ b/src/configure-tests/feature-tests/bvec_merge_data.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct bvec_merge_data bmd;

--- a/src/configure-tests/feature-tests/compound_head.c
+++ b/src/configure-tests/feature-tests/compound_head.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct page *p = NULL;

--- a/src/configure-tests/feature-tests/d_unlinked.c
+++ b/src/configure-tests/feature-tests/d_unlinked.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct dentry d;

--- a/src/configure-tests/feature-tests/dentry_path_raw.c
+++ b/src/configure-tests/feature-tests/dentry_path_raw.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	char *c = NULL;

--- a/src/configure-tests/feature-tests/enum_req_op.c
+++ b/src/configure-tests/feature-tests/enum_req_op.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	enum req_op n = 0;

--- a/src/configure-tests/feature-tests/enum_req_opf.c
+++ b/src/configure-tests/feature-tests/enum_req_opf.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	enum req_opf n = 0;

--- a/src/configure-tests/feature-tests/file_inode.c
+++ b/src/configure-tests/feature-tests/file_inode.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct file *f;

--- a/src/configure-tests/feature-tests/fmode_t.c
+++ b/src/configure-tests/feature-tests/fmode_t.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	fmode_t f;

--- a/src/configure-tests/feature-tests/fops_fallocate.c
+++ b/src/configure-tests/feature-tests/fops_fallocate.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct file f = { .f_version = 0 };

--- a/src/configure-tests/feature-tests/freeze_super.c
+++ b/src/configure-tests/feature-tests/freeze_super.c
@@ -7,6 +7,7 @@
 // 2.6.34 < kernel_version
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct super_block sb;

--- a/src/configure-tests/feature-tests/genhd_fl_no_part_scan.c
+++ b/src/configure-tests/feature-tests/genhd_fl_no_part_scan.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct gendisk gd;

--- a/src/configure-tests/feature-tests/inode_lock.c
+++ b/src/configure-tests/feature-tests/inode_lock.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct inode i;

--- a/src/configure-tests/feature-tests/iops_fallocate.c
+++ b/src/configure-tests/feature-tests/iops_fallocate.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct inode i = { .i_sb = NULL };

--- a/src/configure-tests/feature-tests/kern_path.c
+++ b/src/configure-tests/feature-tests/kern_path.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct path p;

--- a/src/configure-tests/feature-tests/kernel_read_ppos.c
+++ b/src/configure-tests/feature-tests/kernel_read_ppos.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct file *f = NULL;

--- a/src/configure-tests/feature-tests/kernel_write_ppos.c
+++ b/src/configure-tests/feature-tests/kernel_write_ppos.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct file *f = NULL;

--- a/src/configure-tests/feature-tests/make_request_fn_in_queue.c
+++ b/src/configure-tests/feature-tests/make_request_fn_in_queue.c
@@ -7,6 +7,7 @@
 // 5.8 <= kernel_version
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
     make_request_fn *mk_rq_fn;

--- a/src/configure-tests/feature-tests/make_request_fn_int.c
+++ b/src/configure-tests/feature-tests/make_request_fn_int.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static int dummy_mrf(struct request_queue *q, struct bio *bio){
 	return 0;

--- a/src/configure-tests/feature-tests/make_request_fn_void.c
+++ b/src/configure-tests/feature-tests/make_request_fn_void.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static void dummy_mrf(struct request_queue *q, struct bio *bio){
 	return;

--- a/src/configure-tests/feature-tests/merge_bvec_fn.c
+++ b/src/configure-tests/feature-tests/merge_bvec_fn.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static int dummy_merge_bvec(struct request_queue *q, struct bvec_merge_data *bvm, struct bio_vec *bvec){
 	return 0;

--- a/src/configure-tests/feature-tests/mnt_want_write.c
+++ b/src/configure-tests/feature-tests/mnt_want_write.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct vfsmount *mnt;

--- a/src/configure-tests/feature-tests/noop_llseek.c
+++ b/src/configure-tests/feature-tests/noop_llseek.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct file f;

--- a/src/configure-tests/feature-tests/notify_change_2.c
+++ b/src/configure-tests/feature-tests/notify_change_2.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct dentry d;

--- a/src/configure-tests/feature-tests/part_nr_sects_read.c
+++ b/src/configure-tests/feature-tests/part_nr_sects_read.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct hd_struct hd;

--- a/src/configure-tests/feature-tests/path_put.c
+++ b/src/configure-tests/feature-tests/path_put.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct path p;

--- a/src/configure-tests/feature-tests/proc_create_fn_file_operations.c
+++ b/src/configure-tests/feature-tests/proc_create_fn_file_operations.c
@@ -8,6 +8,7 @@
 // 2.6.25 <= kernel_version < 5.6
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
  	static const struct file_operations file_ops;

--- a/src/configure-tests/feature-tests/proc_create_fn_proc_ops.c
+++ b/src/configure-tests/feature-tests/proc_create_fn_proc_ops.c
@@ -7,6 +7,7 @@
 // 5.6 <= kernel_version
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
  	static const struct proc_ops file_ops;

--- a/src/configure-tests/feature-tests/sb_start_write.c
+++ b/src/configure-tests/feature-tests/sb_start_write.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct inode i;

--- a/src/configure-tests/feature-tests/struct_path.c
+++ b/src/configure-tests/feature-tests/struct_path.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct path p;

--- a/src/configure-tests/feature-tests/submit_bio_1.c
+++ b/src/configure-tests/feature-tests/submit_bio_1.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	submit_bio(NULL);

--- a/src/configure-tests/feature-tests/submit_bio_wait.c
+++ b/src/configure-tests/feature-tests/submit_bio_wait.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct bio bio;

--- a/src/configure-tests/feature-tests/sys_oldumount.c
+++ b/src/configure-tests/feature-tests/sys_oldumount.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline int dummy(void){
 	return __NR_umount;

--- a/src/configure-tests/feature-tests/task_struct_task_works_cb_head.c
+++ b/src/configure-tests/feature-tests/task_struct_task_works_cb_head.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct callback_head *ch = current->task_works;

--- a/src/configure-tests/feature-tests/task_struct_task_works_hlist.c
+++ b/src/configure-tests/feature-tests/task_struct_task_works_hlist.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct hlist_head *hl = current->task_works;

--- a/src/configure-tests/feature-tests/thaw_bdev_int.c
+++ b/src/configure-tests/feature-tests/thaw_bdev_int.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct block_device bd;

--- a/src/configure-tests/feature-tests/uapi_mount_h.c
+++ b/src/configure-tests/feature-tests/uapi_mount_h.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 #include <uapi/linux/mount.h>
 
 static inline void dummy(void){

--- a/src/configure-tests/feature-tests/user_path_at.c
+++ b/src/configure-tests/feature-tests/user_path_at.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	user_path_at(0, "dummy", 0, NULL);

--- a/src/configure-tests/feature-tests/uuid_h.c
+++ b/src/configure-tests/feature-tests/uuid_h.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 #include <linux/uuid.h>
 
 static inline void dummy(void){

--- a/src/configure-tests/feature-tests/vfs_fallocate.c
+++ b/src/configure-tests/feature-tests/vfs_fallocate.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct file *f;

--- a/src/configure-tests/feature-tests/vfs_unlink_2.c
+++ b/src/configure-tests/feature-tests/vfs_unlink_2.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct inode i;

--- a/src/configure-tests/feature-tests/vzalloc.c
+++ b/src/configure-tests/feature-tests/vzalloc.c
@@ -6,6 +6,7 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	vzalloc(0);


### PR DESCRIPTION
- Add `MODULE_LICENSE` tag to the feature tests

Now, starting from the kernel 5.11, absence of the `MODULE_LICENSE` has
been treated as error, not a warning as before.
See https://patchwork.kernel.org/project/linux-kbuild/patch/20201201103418.675850-3-masahiroy@kernel.org/
So, feature tests are not compilable without this tag now.

- Added 2 new compats:
   - `bdev_nr_sectors` instead of the `part_nr_sects_read`;
   - `bdev_is_partition` instead of the check of the `bd_contains`, which is a
     member of the disappeared structure `hd_struct` from the `genhd.h`
    
- Done small adjustments for the removed `hd_struct` and its
  members, changed order of the defines around `thaw_super` call in the
  `__tracer_transition_tracing` function.
 
- Added CI build and tests for Ubuntu 20.04 with the kernel 5.11
  Adjusted CI files and `collect_artifacts.sh` to detect distro version and
  name in an easier way and don't fail on Ubuntu.

Resolves #81