### PR TITLE
Support CentOS 8 kernel 4.18.0-305 when MRF is NULL at snap creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,20 +60,6 @@ jobs:
           sleep 5
         working-directory: ${{env.BOX_DIR}}
 
-      # TODO: Remove this step when https://github.com/elastio/elastio-snap/issues/78 is fixed
-      # Here we are downgrading kernel from the 4.18.0-305 to the older one, because the driver hangs on the most recent kernel version
-      - name: Boot CentOS 8 into kernel 4.18.0-240
-        if: "${{ matrix.distro == 'centos8' }}"
-        run: |
-          vagrant ssh ${{env.INSTANCE_NAME}} -c '
-            sudo yum localinstall -y https://vault.centos.org/8.3.2011/BaseOS/x86_64/os/Packages/kernel-core-4.18.0-240.22.1.el8_3.x86_64.rpm
-            sudo yum localinstall -y https://vault.centos.org/8.3.2011/BaseOS/x86_64/os/Packages/kernel-modules-4.18.0-240.22.1.el8_3.x86_64.rpm
-            sudo yum localinstall -y https://vault.centos.org/8.3.2011/BaseOS/x86_64/os/Packages/kernel-4.18.0-240.22.1.el8_3.x86_64.rpm
-            sudo yum localinstall -y https://vault.centos.org/8.3.2011/BaseOS/x86_64/os/Packages/kernel-devel-4.18.0-240.22.1.el8_3.x86_64.rpm
-            sudo reboot now' || true
-          sleep 5
-        working-directory: ${{env.BOX_DIR}}
-
       - name: Build packages
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'make ${PKG_TYPE}'
         working-directory: ${{env.BOX_DIR}}

--- a/src/configure-tests/feature-tests/blk_mq_make_request.c
+++ b/src/configure-tests/feature-tests/blk_mq_make_request.c
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2021 Elastio Software Inc.
+ */
+
+// 5.7 <= kernel_version
+
+#include "includes.h"
+
+static inline void dummy(void){
+	struct request_queue rq;
+	struct bio b;
+	blk_qc_t qc = blk_mq_make_request(&rq, &b);
+	(void)qc;
+}

--- a/src/configure-tests/feature-tests/blk_mq_make_request.c
+++ b/src/configure-tests/feature-tests/blk_mq_make_request.c
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Copyright (C) 2021 Elastio Software Inc.
+ * Copyright (C) 2020 Elastio Software Inc.
  */
 
-// 5.8 == kernel_version
+// kernel_version = 5.8
 
 #include "includes.h"
+#include <linux/blk-mq.h>
 MODULE_LICENSE("GPL");
 
 static inline void dummy(void){

--- a/src/configure-tests/feature-tests/blk_mq_make_request.c
+++ b/src/configure-tests/feature-tests/blk_mq_make_request.c
@@ -4,9 +4,10 @@
  * Copyright (C) 2021 Elastio Software Inc.
  */
 
-// 5.7 <= kernel_version
+// 5.8 == kernel_version
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
 	struct request_queue rq;

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -38,7 +38,7 @@ MODULE_VERSION(ELASTIO_SNAP_VERSION);
 #include <uapi/linux/mount.h>
 #endif
 
-#if defined HAVE_BLK_ALLOC_QUEUE_MK_REQ_FN_NODE_ID || defined USE_BDOPS_SUBMIT_BIO || defined HAVE_BLK_MQ_MAKE_REQUEST
+#if defined HAVE_BLK_MQ_MAKE_REQUEST || defined USE_BDOPS_SUBMIT_BIO
 #include <linux/blk-mq.h>
 #include <linux/percpu-refcount.h>
 #endif
@@ -620,16 +620,11 @@ static inline int elastio_snap_call_mrf(make_request_fn *fn, struct bio *bio){
 }
 #endif
 
-#ifdef HAVE_BLK_ALLOC_QUEUE_MK_REQ_FN_NODE_ID
+#ifdef HAVE_BLK_MQ_MAKE_REQUEST
 // Linux version 5.8
 static inline MRF_RETURN_TYPE elastio_snap_null_mrf(struct request_queue *q, struct bio *bio){
 	percpu_ref_get(&q->q_usage_counter);
 	return blk_mq_make_request(q, bio);
-}
-#elif defined HAVE_BLK_MQ_MAKE_REQUEST
-static inline MRF_RETURN_TYPE elastio_snap_null_mrf(struct request_queue *q, struct bio *bio){
-	smp_wmb();
-	return blk_mq_make_request(q, bio);    
 }
 #endif
 #endif
@@ -3368,40 +3363,24 @@ static int find_orig_mrf(struct block_device *bdev, make_request_fn **mrf){
 	int i;
 	struct snap_device *dev;
 	struct request_queue *q = bdev_get_queue(bdev);
+	make_request_fn *orig_mrf = elastio_snap_get_bd_mrf(bdev);
 
-	if(elastio_snap_get_bd_mrf(bdev) != tracing_mrf){
-#ifndef HAVE_BLK_ALLOC_QUEUE_MK_REQ_FN_NODE_ID
+	if(orig_mrf != tracing_mrf){
+#if defined HAVE_BLK_MQ_MAKE_REQUEST || defined USE_BDOPS_SUBMIT_BIO
+		// Linux version 5.8+
+		if (!orig_mrf){
 #ifdef USE_BDOPS_SUBMIT_BIO
-		// Linux version 5.9+
-		*mrf = elastio_snap_get_bd_mrf(bdev);
-		if (!*mrf){
-			if (elastio_blk_mq_submit_bio){
-				*mrf = elastio_snap_null_mrf;
-				LOG_DEBUG("original submit_bio is empty, set to elastio_snap_null_mrf");
-			}else{
+			// Linux version 5.9+
+			if (!elastio_blk_mq_submit_bio){
 				LOG_ERROR(-EFAULT, "error finding original mrf, original submit_bio and elastio_snap_null_mrf both are empty");
 				return -EFAULT;
 			}
-		}
-#else
-		// Linux versions older than 5.8
-		*mrf = q->make_request_fn;
-#ifdef HAVE_BLK_MQ_MAKE_REQUEST
-		if (!*mrf)
-		{
-			*mrf = elastio_snap_null_mrf;
-			LOG_DEBUG("original mrf is empty, set to elastio_snap_null_mrf with blk_mq_make_request");
-		}
-#endif        
 #endif
-#else
-		// Linux version 5.8
-		if (q->make_request_fn) *mrf = q->make_request_fn;
-		else{
-			*mrf = elastio_snap_null_mrf;
+			orig_mrf = elastio_snap_null_mrf;
 			LOG_DEBUG("original mrf is empty, set to elastio_snap_null_mrf");
 		}
 #endif
+		*mrf = orig_mrf;
 		return 0;
 	}
 
@@ -3483,8 +3462,8 @@ static int __tracer_transition_tracing(struct snap_device *dev, struct block_dev
 		if(new_mrf) elastio_snap_set_bd_mrf(bdev, new_mrf);
 	}else{
 		LOG_DEBUG("ending tracing");
-#if defined HAVE_BLK_ALLOC_QUEUE_MK_REQ_FN_NODE_ID || defined USE_BDOPS_SUBMIT_BIO
-// Linux version 5.8
+#if defined HAVE_BLK_MQ_MAKE_REQUEST || defined USE_BDOPS_SUBMIT_BIO
+// Linux version 5.8+
 		if(new_mrf) elastio_snap_set_bd_mrf(bdev, new_mrf == elastio_snap_null_mrf ? NULL : new_mrf);
 #else
 		if(new_mrf) elastio_snap_set_bd_mrf(bdev, new_mrf);

--- a/src/includes.h
+++ b/src/includes.h
@@ -11,8 +11,6 @@
 #include <linux/module.h>
 #include <linux/moduleparam.h>
 #include <linux/blkdev.h>
-#include <linux/blk_types.h>
-#include <linux/blk-mq.h>
 #include <linux/genhd.h>
 #include <linux/kthread.h>
 #include <linux/miscdevice.h>

--- a/src/includes.h
+++ b/src/includes.h
@@ -11,6 +11,8 @@
 #include <linux/module.h>
 #include <linux/moduleparam.h>
 #include <linux/blkdev.h>
+#include <linux/blk_types.h>
+#include <linux/blk-mq.h>
 #include <linux/genhd.h>
 #include <linux/kthread.h>
 #include <linux/miscdevice.h>


### PR DESCRIPTION
Closes #78 

CentOS 8 kernel 4.18.0-305 does contain some new stuff from 5.x newer
kernels. Also, on this kernel it's possible to have default MRF==NULL at
snap creation stage.
So in this case we have to create default MRF by blk_mq_make_request
kernel API function which is one of those new ones imported by
CentOS 8 from the newer kernels.

Added compat for blk_mq_make_request.