### PR TITLE
Fix stuck on Debian 11

### DIFF
--- a/.github/buildbox/Vagrantfile
+++ b/.github/buildbox/Vagrantfile
@@ -29,7 +29,7 @@ EOF
 chmod +x /etc/profile.d/set_build_env.sh
 ENV_VARS_SCRIPT
 
-DISTROS = [ "debian8", "debian9", "debian10",
+DISTROS = [ "debian8", "debian9", "debian10", "debian11",
             "amazon2",
             "centos6", "centos7", "centos8",
             "fedora31", "fedora32",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         distro: [
-          debian8, debian9, debian10,
+          debian8, debian9, debian10, debian11,
           centos7, centos8,
           amazon2,
           fedora31, fedora32,

--- a/src/configure-tests/feature-tests/blk_mq_submit_bio.c
+++ b/src/configure-tests/feature-tests/blk_mq_submit_bio.c
@@ -5,6 +5,7 @@
  */
 
 #include "includes.h"
+#include <linux/blk-mq.h>
 MODULE_LICENSE("GPL");
 
 static inline void dummy(void){

--- a/src/genconfig.sh
+++ b/src/genconfig.sh
@@ -24,9 +24,16 @@ fi
 
 SYSTEM_MAP_FILE="/lib/modules/${KERNEL_VERSION}/System.map"
 
-if [ ! -f "$SYSTEM_MAP_FILE" ]; then
-	# Use fallback location
-	SYSTEM_MAP_FILE="/boot/System.map-${KERNEL_VERSION}"
+# Use standard location at the /boot
+[ ! -f "$SYSTEM_MAP_FILE" ] && SYSTEM_MAP_FILE="/boot/System.map-${KERNEL_VERSION}"
+if [ ! -f "$SYSTEM_MAP_FILE" ] || [ $(cat "$SYSTEM_MAP_FILE" | wc -l) -lt 10 ]; then
+	# The build is running on Debian 11+. File /boot/System.map-${KERNEL_VERSION} exists, but it
+	# contains just a single line.
+	# Maybe package linux-image-$(uname -r)-dbg is installed...
+	SYSTEM_MAP_FILE="/usr/lib/debug/boot/System.map-${KERNEL_VERSION}"
+
+	# Use fallback option
+	[ ! -f "$SYSTEM_MAP_FILE" ] && SYSTEM_MAP_FILE="/proc/kallsyms"    
 fi
 
 


### PR DESCRIPTION
- Fix blk_mq_submit_bio compat.
- Fix build script for asm-linkage on Debian-11 by using it's specific
  map file.
- Use blk_mq_submit_bio as asm-linkable for all 5.9+ kernels.

Also handled specific Debian 11 only case with the empty but existing
/boot/System.map-kernel_ver file.
See https://www.mail-archive.com/debian-devel@lists.debian.org/msg369037.html

Used 2 workarounds:
1) Try /usr/lib/debug/boot/System.map-kern_ver location if package
   linux-image-$(uname -r)-dbg is installed.
2) Unfortunately option 1 isn't a case when the new kernel version is just
   installed and DKMS is used to build our module. Using /proc/kallsyms
   in this case is Ok, because relative function addresses has been used in the
   code.
   
Closes #83 