### PR TITLE
Trigger repo build with the new payload

### DIFF
--- a/.github/scripts/dispatch_packaging.sh
+++ b/.github/scripts/dispatch_packaging.sh
@@ -6,4 +6,4 @@ set -x
 curl -XPOST -u "$REPO_HOOK_TOKEN" \
      -H "Accept: application/vnd.github.everest-preview+json" \
      -H "Content-Type: application/json" https://api.github.com/repos/elastio/packaging/dispatches \
-     --data '{ "event_type": "elastio-snap #'$GITHUB_RUN_NUMBER': '$GITHUB_EVENT_NAME' '$where_from' '$SOURCE_BRANCH'", "client_payload": { "branch": "'$SOURCE_BRANCH'" } }'
+     --data '{ "event_type": "elastio-snap #'$GITHUB_RUN_NUMBER': '$GITHUB_EVENT_NAME' '$where_from' '$SOURCE_BRANCH'", "client_payload": { "src_branch": "'$SOURCE_BRANCH'", "tgt_branch": "'$SOURCE_BRANCH'" } }'


### PR DESCRIPTION
Now we have to specify source and target branches.
For the elastio-snap they are always equal.
The change is just to honor new format.

Related to https://github.com/elastio/packaging/issues/128