### PR TITLE
Linux kernel 5.15 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,15 @@ jobs:
           sleep 5
         working-directory: ${{env.BOX_DIR}}
 
+      - name: Boot Fedora 35 into kernel 5.15
+        if: "${{ matrix.distro == 'fedora35' }}"
+        run: |
+          vagrant ssh ${{env.INSTANCE_NAME}} -c '
+            sudo yum update -y kernel kernel-devel
+            sudo reboot now' || true
+          sleep 5
+        working-directory: ${{env.BOX_DIR}}
+
       - name: Build packages
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'make ${PKG_TYPE}'
         working-directory: ${{env.BOX_DIR}}

--- a/src/configure-tests/feature-tests/alloc_disk.c
+++ b/src/configure-tests/feature-tests/alloc_disk.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+// kernel_version < 5.15
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+    struct gendisk *disk = alloc_disk(1);
+	(void)disk;
+}

--- a/src/configure-tests/feature-tests/disk_live.c
+++ b/src/configure-tests/feature-tests/disk_live.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+// kernel_version < 5.15
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+    bool ret;
+    struct gendisk disk;
+    ret = disk_live(&disk);
+    (void)ret;
+}

--- a/src/configure-tests/feature-tests/locks_verify_truncate.c
+++ b/src/configure-tests/feature-tests/locks_verify_truncate.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+// kernel_version < 5.15
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+    struct file filp;
+    loff_t len;
+    struct inode *inode;
+    int ret;
+    ret = locks_verify_truncate(&inode, &filp, len);
+}

--- a/src/configure-tests/symbol-tests
+++ b/src/configure-tests/symbol-tests
@@ -2,8 +2,7 @@ sys_mount
 sys_umount
 sys_oldumount
 sys_call_table
-printk
+kfree
 blk_mq_submit_bio
 blk_alloc_queue
 get_super
-drop_super


### PR DESCRIPTION
- Added compats for the removed functions `locks_verify_truncate` and
  `alloc_disk`.
- Added compat for the added function `disk_live`.
- Replaced anchor address of the `printk` function with the address of
  the `kfree` function. `printk` still exists in the kernel 5.15, but
  it's a macros around `_printk`. So, `printk` doesn't have an address
  in the `System.map` or `/proc/kallsyms` files.
- Removed redundant `elastio_snap_drop_super` function and simplified
  logic around `elastio_snap_get_super`. The last one is necessary,
  because `get_super` function is not exported since 5.11.