### PR TITLE
Fix ability to take snapshots from the multiple devices at one time on kernels 5.9+

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -8,12 +8,13 @@
 
 import errno
 import os
+import subprocess
 import unittest
+from random import randint
 
 import elastio_snap
 import util
 from devicetestcase import DeviceTestCase
-
 
 class TestSetup(DeviceTestCase):
     def setUp(self):
@@ -75,6 +76,46 @@ class TestSetup(DeviceTestCase):
         self.assertEqual(snapdev["bdev"], self.device)
         self.assertEqual(snapdev["version"], 1)
 
+    def test_setup_2_volumes(self):
+        # Setup device #1 at the root volume
+        minor = randint(0, 23)
+        cmd = ["findmnt", "/", "-n", "-o", "SOURCE"]
+        device = subprocess.check_output(cmd, timeout=10, shell=False).rstrip().decode("utf-8")
+        snap_device = "/dev/elastio-snap{}".format(minor)
+        cow_file = "cow"
+
+        self.assertEqual(elastio_snap.setup(minor, device, "/{}".format(cow_file)), 0)
+
+        # Check the snapshot device exists and alive
+        self.assertTrue(os.path.exists(snap_device))
+
+        snapdev = elastio_snap.info(minor)
+        self.assertIsNotNone(snapdev)
+
+        self.assertEqual(snapdev["error"], 0)
+        self.assertEqual(snapdev["state"], 3)
+        self.assertEqual(snapdev["cow"], "/{}".format(cow_file))
+        self.assertEqual(snapdev["bdev"], device)
+        self.assertEqual(snapdev["version"], 1)
+
+        # Setup device number 2, as ususally on an external disk or on a loopback device
+        self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)
+        self.addCleanup(elastio_snap.destroy, self.minor)
+
+        # Check the 2nd snapshot device
+        self.assertTrue(os.path.exists(self.snap_device))
+
+        snapdev = elastio_snap.info(self.minor)
+        self.assertIsNotNone(snapdev)
+
+        self.assertEqual(snapdev["error"], 0)
+        self.assertEqual(snapdev["state"], 3)
+        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
+        self.assertEqual(snapdev["bdev"], self.device)
+        self.assertEqual(snapdev["version"], 1)
+
+        # Destroy 1st snapshot device
+        self.assertEqual(elastio_snap.destroy(minor), 0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -79,6 +79,9 @@ class TestSetup(DeviceTestCase):
     def test_setup_2_volumes(self):
         # Setup device #1 at the root volume
         minor = randint(0, 23)
+        while minor == self.minor:
+          minor = randint(0, 23)
+
         cmd = ["findmnt", "/", "-n", "-o", "SOURCE"]
         device = subprocess.check_output(cmd, timeout=10, shell=False).rstrip().decode("utf-8")
         snap_device = "/dev/elastio-snap{}".format(minor)


### PR DESCRIPTION
This change helps to avoid hack with the replacement of the `const` member
function `submit_bio` in the `block_device_operations` structure.
So, now there is no need to disable/enable page protection when
tracing is started/stopped. Entire struct for the traced device is replaced now.
As experiment showed, this struct can be shared between multiple
devices. That was a root cause of the bug.

Also introduced new func `find_orig_fops` which is very like the
existing func `find_orig_mrf`. This is done to reduce count of
precompilation directives in the original function, which became
unreadable at all if still combined for kernels older and newer than 5.9.

Resolves #100 