### PR TITLE
Support kernel 5.16

### DIFF
--- a/.github/buildbox/Vagrantfile
+++ b/.github/buildbox/Vagrantfile
@@ -4,7 +4,6 @@
 Vagrant.require_version ">= 1.6.2"
 
 $box_version=">= 20.9.9"
-$box_version_fedora35="<= 22.1.31"
 
 pid = Process.pid
 
@@ -52,11 +51,6 @@ Vagrant.configure("2") do |config|
     config.vm.define "#{instance}", autostart: false do |b|
       b.vm.box = "#{box}"
       b.vm.box_url = [ "https://s3.eu-central-1.wasabisys.com/blobs-wasabi.elastio.dev/devboxes/master/#{box}.json" ]
-      if (distro == "fedora34") || (distro == "fedora35")
-        b.vm.box_version = $box_version_fedora35
-      else
-        b.vm.box_version = $box_version
-      end
     end
 
     config.trigger.before :"Vagrant::Action::Builtin::BoxAdd", type: :action do |trigger|

--- a/.github/buildbox/Vagrantfile
+++ b/.github/buildbox/Vagrantfile
@@ -51,6 +51,7 @@ Vagrant.configure("2") do |config|
     config.vm.define "#{instance}", autostart: false do |b|
       b.vm.box = "#{box}"
       b.vm.box_url = [ "https://s3.eu-central-1.wasabisys.com/blobs-wasabi.elastio.dev/devboxes/master/#{box}.json" ]
+	  b.vm.box_version = $box_version
     end
 
     config.trigger.before :"Vagrant::Action::Builtin::BoxAdd", type: :action do |trigger|

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,24 +58,6 @@ jobs:
           sleep 5
         working-directory: ${{env.BOX_DIR}}
 
-      - name: Boot Fedora 34 into latest kernel
-        if: "${{ matrix.distro == 'fedora34' }}"
-        run: |
-          vagrant ssh ${{env.INSTANCE_NAME}} -c '
-            sudo yum update -y kernel kernel-devel
-            sudo reboot now' || true
-          sleep 5
-        working-directory: ${{env.BOX_DIR}}
-        
-      - name: Boot Fedora 35 into latest kernel
-        if: "${{ matrix.distro == 'fedora35' }}"
-        run: |
-          vagrant ssh ${{env.INSTANCE_NAME}} -c '
-            sudo yum update -y kernel kernel-devel
-            sudo reboot now' || true
-          sleep 5
-        working-directory: ${{env.BOX_DIR}}
-
       - name: Build packages
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'make ${PKG_TYPE}'
         working-directory: ${{env.BOX_DIR}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,15 @@ jobs:
           sleep 5
         working-directory: ${{env.BOX_DIR}}
 
+      - name: Boot Fedora 34, 35 into latest kernel
+        if: "${{ matrix.distro == 'fedora34' || matrix.distro == 'fedora35' }}"
+        run: |
+          vagrant ssh ${{env.INSTANCE_NAME}} -c '
+            sudo yum update -y kernel kernel-devel
+            sudo reboot now' || true
+          sleep 5
+        working-directory: ${{env.BOX_DIR}}
+
       - name: Build packages
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'make ${PKG_TYPE}'
         working-directory: ${{env.BOX_DIR}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,15 @@ jobs:
           sleep 5
         working-directory: ${{env.BOX_DIR}}
 
+      - name: Boot Fedora 34 into latest kernel
+        if: "${{ matrix.distro == 'fedora34' }}"
+        run: |
+          vagrant ssh ${{env.INSTANCE_NAME}} -c '
+            sudo yum update -y kernel kernel-devel
+            sudo reboot now' || true
+          sleep 5
+        working-directory: ${{env.BOX_DIR}}
+        
       - name: Boot Fedora 35 into latest kernel
         if: "${{ matrix.distro == 'fedora35' }}"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
           sleep 5
         working-directory: ${{env.BOX_DIR}}
 
-      - name: Boot Fedora 34, 35 into latest kernel
-        if: "${{ matrix.distro == 'fedora34' || matrix.distro == 'fedora35' }}"
+      - name: Boot Fedora 35 into latest kernel
+        if: "${{ matrix.distro == 'fedora35' }}"
         run: |
           vagrant ssh ${{env.INSTANCE_NAME}} -c '
             sudo yum update -y kernel kernel-devel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,15 @@ jobs:
           sleep 5
         working-directory: ${{env.BOX_DIR}}
 
+      - name: Boot Fedora 35 into latest kernel
+        if: "${{ matrix.distro == 'fedora35' }}"
+        run: |
+          vagrant ssh ${{env.INSTANCE_NAME}} -c '
+            sudo yum update -y kernel kernel-devel
+            sudo reboot now' || true
+          sleep 5
+        working-directory: ${{env.BOX_DIR}}
+
       - name: Build packages
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'make ${PKG_TYPE}'
         working-directory: ${{env.BOX_DIR}}

--- a/src/configure-tests/feature-tests/add_disk_int.c
+++ b/src/configure-tests/feature-tests/add_disk_int.c
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+// kernel_version < 5.15
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct gendisk disk;
+	int ret = add_disk(&disk);
+	(void)ret;
+}

--- a/src/configure-tests/feature-tests/bdops_submit_bio.c
+++ b/src/configure-tests/feature-tests/bdops_submit_bio.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2020 Elastio Software Inc.
  */
 
-// 5.9 <= kernel_version
+// kernel_version >= 5.16
 
 #include "includes.h"
 MODULE_LICENSE("GPL");

--- a/src/configure-tests/feature-tests/bdops_submit_bio_uint.c
+++ b/src/configure-tests/feature-tests/bdops_submit_bio_uint.c
@@ -9,9 +9,9 @@
 #include "includes.h"
 MODULE_LICENSE("GPL");
 
-static void snap_submit_bio(struct bio *bio)
+static blk_qc_t snap_submit_bio(struct bio *bio)
 {
-	(void)bio;
+	return BLK_QC_T_NONE;
 }
 
 static inline void dummy(void){

--- a/src/configure-tests/feature-tests/genhd_fl_no_part.c
+++ b/src/configure-tests/feature-tests/genhd_fl_no_part.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2015 Datto Inc.
+ * Additional contributions by Elastio Software, Inc are Copyright (C) 2020 Elastio Software Inc.
+ */
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct gendisk gd;
+	gd.flags = GENHD_FL_NO_PART;
+}

--- a/src/configure-tests/feature-tests/genhd_fl_no_part.c
+++ b/src/configure-tests/feature-tests/genhd_fl_no_part.c
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Copyright (C) 2015 Datto Inc.
- * Additional contributions by Elastio Software, Inc are Copyright (C) 2020 Elastio Software Inc.
+ * Copyright (C) 2020 Elastio Software Inc.
  */
+
+// kernel_version >= 5.17
 
 #include "includes.h"
 MODULE_LICENSE("GPL");

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -672,6 +672,8 @@ static inline MRF_RETURN_TYPE elastio_snap_null_mrf(struct request_queue *q, str
 // Also elastio_blk_mq_submit_bio is set to NULL in case if address of the blk_mq_submit_bio function is not detected for further checks.
 MRF_RETURN_TYPE (*elastio_blk_mq_submit_bio)(struct bio *) = (BLK_MQ_SUBMIT_BIO_ADDR != 0) ?
 	(MRF_RETURN_TYPE (*)(struct bio *)) (BLK_MQ_SUBMIT_BIO_ADDR + (long long)(((void *)kfree) - (void *)KFREE_ADDR)) : NULL;
+#else
+MRF_RETURN_TYPE (*elastio_blk_mq_submit_bio)(struct bio *) = blk_mq_submit_bio;
 #endif
 
 static inline MRF_RETURN_TYPE elastio_snap_null_mrf(struct bio *bio){
@@ -4032,11 +4034,15 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor, stru
 
 	//register gendisk with the kernel
 	LOG_DEBUG("adding disk");
+	#ifdef HAVE_ADD_DISK_INT
 	ret = add_disk(dev->sd_gd);
 	if(ret){
 		LOG_ERROR(ret, "error adding disk");
 		goto error;
 	}
+	#else
+	add_disk(dev->sd_gd);
+	#endif
 
 	LOG_DEBUG("starting mrf kernel thread");
 	dev->sd_mrf_thread = kthread_run(snap_mrf_thread, dev, SNAP_MRF_THREAD_NAME_FMT, minor);

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -665,16 +665,12 @@ static inline MRF_RETURN_TYPE elastio_snap_null_mrf(struct request_queue *q, str
 #ifdef USE_BDOPS_SUBMIT_BIO
 // Linux version 5.9+
 
-#ifndef HAVE_BLK_MQ_SUBMIT_BIO
 // The blk_mq_submit_bio function was exported in the kernels 5.9.0 - 5.9.1. And starting from the 5.9.2 it doesn't.
 // And compat HAVE_BLK_MQ_SUBMIT_BIO doesn't allow us to detect whether it exported or not.
 // Anyway this call by address works in all cases for the kernels 5.9+.
 // Also elastio_blk_mq_submit_bio is set to NULL in case if address of the blk_mq_submit_bio function is not detected for further checks.
 MRF_RETURN_TYPE (*elastio_blk_mq_submit_bio)(struct bio *) = (BLK_MQ_SUBMIT_BIO_ADDR != 0) ?
 	(MRF_RETURN_TYPE (*)(struct bio *)) (BLK_MQ_SUBMIT_BIO_ADDR + (long long)(((void *)kfree) - (void *)KFREE_ADDR)) : NULL;
-#else
-MRF_RETURN_TYPE (*elastio_blk_mq_submit_bio)(struct bio *) = blk_mq_submit_bio;
-#endif
 
 static inline MRF_RETURN_TYPE elastio_snap_null_mrf(struct bio *bio){
 	#ifndef MRF_RETURN_TYPE_VOID

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -4030,6 +4030,11 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor, stru
 	dev->sd_gd->flags |= GENHD_FL_NO_PART_SCAN;
 #endif
 
+#ifdef HAVE_GENHD_FL_NO_PART
+	// the flag has been renamed in 5.17
+	dev->sd_gd->flags |= GENHD_FL_NO_PART;
+#endif
+
 	//set the device as read-only
 	set_disk_ro(dev->sd_gd, 1);
 

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -624,15 +624,15 @@ static inline int elastio_snap_call_mrf(make_request_fn *fn, struct bio *bio){
 	return 0;
 }
 #else
-	#ifdef HAVE_BDOPS_SUBMIT_BIO_UINT
-		// Linux kernel version 5.9 - 5.15
-		#define MRF_RETURN_TYPE blk_qc_t
-		#define MRF_RETURN(ret) return BLK_QC_T_NONE
-	#else
+	#ifdef HAVE_BDOPS_SUBMIT_BIO
 		// Linux kernel version 5.16+
 		#define MRF_RETURN_TYPE void
 		#define MRF_RETURN(ret) return
 		#define MRF_RETURN_TYPE_VOID
+	#else
+		// Linux kernel version 5.9 - 5.15
+		#define MRF_RETURN_TYPE blk_qc_t
+		#define MRF_RETURN(ret) return BLK_QC_T_NONE
 	#endif
 
 #ifndef USE_BDOPS_SUBMIT_BIO


### PR DESCRIPTION
- Changed MRF function result type to VOID,
  added helper macroses for that.

- Started from 5.15 blk_cleanup_queue should be called
  right before put_disk.
  
Closes #106 