### PR TITLE
Fix module compilation on some 2.X, 3.X, 4.X kernels

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
 # elastio-snap INSTALL
 
 ## From Repositories
-Elastio Software Inc. provides repositories for x86_64 editions of the RHEL/CentOS starting from the version 6.10, Amazon Linux 2, Fedora 31 and newer, Debian 8 and newer, and Ubuntu LTS starting from the version 16.04.
+Elastio Software Inc. provides repositories for x86_64 editions of the RHEL/CentOS starting from the version 7, Amazon Linux 2, Fedora 31 and newer, Debian 8 and newer, and Ubuntu LTS starting from the version 16.04.
 We recommend that you install the kernel module from Elastio's repositories.
 
 ### Repository package installation for RPM-based systems

--- a/src/configure-tests/feature-tests/si_mem_available.c
+++ b/src/configure-tests/feature-tests/si_mem_available.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+// kernel_version = 3.16, 4.4, 4.6+
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	long res;
+	res = si_mem_available();
+}

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -771,6 +771,20 @@ static inline void elastio_snap_bio_copy_dev(struct bio *dst, struct bio *src){
 #define dev_bioset(dev) (&(dev)->sd_bioset)
 #endif
 
+#ifndef __kernel_long_t
+typedef long __kernel_long_t;
+typedef unsigned long __kernel_ulong_t;
+#endif
+
+#ifndef HAVE_SI_MEM_AVAILABLE
+__kernel_ulong_t si_mem_available(void)
+{
+       struct sysinfo si;
+       si_meminfo(&si);
+       return si.freeram;
+}
+#endif
+
 /*********************************MACRO/PARAMETER DEFINITIONS*******************************/
 
 
@@ -5535,7 +5549,7 @@ static void elastio_snap_wait_for_release(struct snap_device *dev)
 	// Linux kernel version 5.14+
 	int prev_state = READ_ONCE(current->__state);
 #else
-	int prev_state = READ_ONCE(current->state);
+	int prev_state = ACCESS_ONCE(current->state);
 #endif
 	int i = 0;
 	set_current_state(TASK_INTERRUPTIBLE);

--- a/src/genconfig.sh
+++ b/src/genconfig.sh
@@ -27,13 +27,18 @@ SYSTEM_MAP_FILE="/lib/modules/${KERNEL_VERSION}/System.map"
 # Use standard location at the /boot
 [ ! -f "$SYSTEM_MAP_FILE" ] && SYSTEM_MAP_FILE="/boot/System.map-${KERNEL_VERSION}"
 if [ ! -f "$SYSTEM_MAP_FILE" ] || [ $(cat "$SYSTEM_MAP_FILE" | wc -l) -lt 10 ]; then
-	# The build is running on Debian 11+. File /boot/System.map-${KERNEL_VERSION} exists, but it
-	# contains just a single line.
-	# Maybe package linux-image-$(uname -r)-dbg is installed...
+	# File /boot/System.map-${KERNEL_VERSION} exists, but it contains just a single line on Debian 11+.
+	# Package linux-image-$(uname -r)-dbg installs normal map file.
 	SYSTEM_MAP_FILE="/usr/lib/debug/boot/System.map-${KERNEL_VERSION}"
 
 	# Use fallback option
-	[ ! -f "$SYSTEM_MAP_FILE" ] && SYSTEM_MAP_FILE="/proc/kallsyms"    
+	if [ ! -f "$SYSTEM_MAP_FILE" ]; then
+		SYSTEM_MAP_FILE="/proc/kallsyms"
+		if [ "$EUID" -ne 0 ]; then
+			echo "Run 'make' command as sudo or root. Otherwise it is not possible to get addresses from the $SYSTEM_MAP_FILE"
+			exit 1
+		fi
+	fi
 fi
 
 


### PR DESCRIPTION
- Fix module compilation due to absence of `si_mem_available` in some
  kernels

  This function is used to check available memory. However it has very
  strange history. The function has been added in 3.16. But then it
  disappears in the 3.17 and then appears back in the 4.4 and then it
  disappears again in 4.5 and then appears back in 4.6.

  Closes #116

- Fix warning during compilation on some 2.X, 3.X, 4.X kernels

  Macros `READ_ONCE` produces warning during compilation on some old
  kernels when it's used for `current->state`.

- Deny to `make` module w\o `sudo` when it can be done, but produces
  a non-working kernel object file.