### PR TITLE
Fix syscall table location and add support of arm64 architecture

### DIFF
--- a/.github/buildbox/Vagrantfile
+++ b/.github/buildbox/Vagrantfile
@@ -29,11 +29,17 @@ EOF
 chmod +x /etc/profile.d/set_build_env.sh
 ENV_VARS_SCRIPT
 
-DISTROS = [ "debian8", "debian9", "debian10", "debian11",
-            "amazon2",
-            "centos6", "centos7", "centos8",
-            "fedora31", "fedora32", "fedora34", "fedora35", "fedora36",
-            "ubuntu2004", "ubuntu2204" ]
+DISTRO = {}
+DISTRO['amd64'] = [ "debian8", "debian9", "debian10", "debian11",
+                     "amazon2",
+                     "centos6", "centos7", "centos8",
+                     "fedora31", "fedora32", "fedora34", "fedora35", "fedora36",
+                     "ubuntu2004", "ubuntu2204" ]
+
+DISTRO['arm64'] = [ "debian10", "debian11",
+                     "amazon2",
+                     "centos8",
+                     "fedora35", "fedora36" ]
 
 # NOTE: This environment variable should be set to enable triggers of the type "action".
 # The actions are used to make a lock around Vagrant::Action::Builtin::BoxAdd to avoid
@@ -44,8 +50,16 @@ ENV['VAGRANT_EXPERIMENTAL']='typed_triggers' if ARGV.include?('up')
 
 Vagrant.configure("2") do |config|
 
-  DISTROS.each do |distro|
-    box = "#{distro}-amd64-build"
+  # Get runner architecture
+  arch =`uname -m`.strip
+  if arch == "x86_64"
+    arch = "amd64"
+  elsif arch == "aarch64"
+    arch = "arm64"
+  end
+
+  DISTRO["#{arch}"].each do |distro|
+    box = "#{distro}-#{arch}-build"
     instance = "#{box}-#{ENV['RUNNER_NUM']}"
     next if ARGV.include?('up') && ARGV.none?("#{instance}")
     config.vm.define "#{instance}", autostart: false do |b|

--- a/.github/buildbox/Vagrantfile
+++ b/.github/buildbox/Vagrantfile
@@ -31,15 +31,16 @@ ENV_VARS_SCRIPT
 
 DISTRO = {}
 DISTRO['amd64'] = [ "debian8", "debian9", "debian10", "debian11",
-                     "amazon2",
-                     "centos6", "centos7", "centos8",
-                     "fedora31", "fedora32", "fedora34", "fedora35", "fedora36",
-                     "ubuntu2004", "ubuntu2204" ]
+                    "amazon2",
+                    "centos6", "centos7", "centos8",
+                    "fedora31", "fedora32", "fedora34", "fedora35", "fedora36",
+                    "ubuntu2004", "ubuntu2204" ]
 
 DISTRO['arm64'] = [ "debian10", "debian11",
-                     "amazon2",
-                     "centos8",
-                     "fedora35", "fedora36" ]
+                    "amazon2",
+                    "centos8",
+                    "fedora35", "fedora36",
+                    "ubuntu2204" ]
 
 # NOTE: This environment variable should be set to enable triggers of the type "action".
 # The actions are used to make a lock around Vagrant::Action::Builtin::BoxAdd to avoid

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,11 @@ jobs:
           sleep 5
         working-directory: ${{env.BOX_DIR}}
 
+      - name: Remove devtoolset
+        if: "${{ matrix.distro == 'amazon2' && matrix.arch == 'arm64' }}"
+        run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'sudo rm /etc/profile.d/enable-llvm-toolset.sh'
+        working-directory: ${{env.BOX_DIR}}
+
       - name: Build packages
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'make ${PKG_TYPE}'
         working-directory: ${{env.BOX_DIR}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build Packages
     runs-on:
       - metal
-      # - {{ matrix.arch }}
+      - ${{ matrix.arch }}
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,15 +117,6 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
         timeout-minutes: 5
 
-      - name: Upload artifacts
-        # upload amd64 only, should work for both architectures
-        run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'AWS_SECRET_ACCESS_KEY='"'$AWS_SECRET_ACCESS_KEY'"' repobuild/upload.sh
-          --source repobuild/artifacts/
-          --bucket artifacts.assur.io
-          --target /linux/elastio-snap/${SOURCE_BRANCH}/${GITHUB_RUN_NUMBER}/${PKG_TYPE}
-          --exclude *GPG-KEY'
-        working-directory: ${{env.BOX_DIR}}
-
       - name: Destroy a box
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,14 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
         timeout-minutes: 5
 
+      - name: Detach external drive
+        if: always()
+        run: |
+          if virsh domblklist ${BOX_DIR##*/}_${INSTANCE_NAME} --details | grep "file" | awk '{ print $NF }' | grep ${TEST_IMAGE} ; then
+              virsh detach-disk --domain ${BOX_DIR##*/}_${INSTANCE_NAME} ${TEST_IMAGE}
+          fi
+          rm -f ${TEST_IMAGE}
+
       - name: Upload artifacts
         # upload amd64 only, should work for both architectures
         run: |
@@ -151,9 +159,7 @@ jobs:
 
       - name: Destroy a box
         if: always()
-        run: |
-          .github/scripts/destroy_box.sh
-          rm -f ${TEST_IMAGE}
+        run: .github/scripts/destroy_box.sh
 
   manifest:
     name: Artifacts manifest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ jobs:
   build-packages:
     name: Build Packages
     runs-on:
-      - baremetal
+      - metal
+      # - {{ matrix.arch }}
 
     strategy:
       matrix:
@@ -24,6 +25,19 @@ jobs:
           ubuntu2004, ubuntu2204
         ]
         arch: [ amd64 ]
+        include:
+          - arch: arm64
+            distro: amazon2
+          - arch: arm64
+            distro: fedora35
+          - arch: arm64
+            distro: fedora36
+          - arch: arm64
+            distro: debian10
+          - arch: arm64
+            distro: debian11
+          - arch: arm64
+            distro: centos8
 
     steps:
       - name: Checkout sources
@@ -47,7 +61,7 @@ jobs:
         run: .github/scripts/start_box.sh
 
       - name: Boot Fedora 32 into kernel 5.9
-        if: "${{ matrix.distro == 'fedora32' }}"
+        if: "${{ matrix.distro == 'fedora32' && matrix.arch == 'amd64' }}"
         run: |
           vagrant ssh ${{env.INSTANCE_NAME}} -c '
             sudo yum localinstall -y https://kojipkgs.fedoraproject.org//packages/kernel/5.9.16/100.fc32/x86_64/kernel-core-5.9.16-100.fc32.x86_64.rpm
@@ -101,6 +115,8 @@ jobs:
           rm -f ${TEST_IMAGE}
 
       - name: Upload artifacts
+        # upload amd64 only, should work for both architectures
+        if: "${{ matrix.arch == 'amd64' }}"
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'AWS_SECRET_ACCESS_KEY='"'$AWS_SECRET_ACCESS_KEY'"' repobuild/upload.sh
           --source repobuild/artifacts/
           --bucket artifacts.assur.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,9 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
 
       - name: Install kernel module
-        run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'sudo make install'
+        run: |
+          vagrant ssh ${{env.INSTANCE_NAME}} -c 'sudo make install'
+          vagrant ssh ${{env.INSTANCE_NAME}} -c 'sudo make uninstall'
         working-directory: ${{env.BOX_DIR}}
 
       - name: Run tests (loop device)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,6 @@ jobs:
           rm -f ${TEST_IMAGE}
 
       - name: Upload artifacts
-        # upload amd64 only, should work for both architectures
         run: |
           excl_ptrn="*GPG-KEY"
           # We have to avoid a race condition when package like elastio-snap-dkms_X.XX.XX-1debian11_all.deb is uploaded from

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,15 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
         timeout-minutes: 5
 
+      - name: Upload artifacts
+        # upload amd64 only, should work for both architectures
+        run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'AWS_SECRET_ACCESS_KEY='"'$AWS_SECRET_ACCESS_KEY'"' repobuild/upload.sh
+          --source repobuild/artifacts/
+          --bucket artifacts.assur.io
+          --target /linux/elastio-snap/${SOURCE_BRANCH}/${GITHUB_RUN_NUMBER}/${PKG_TYPE}
+          --exclude *GPG-KEY'
+        working-directory: ${{env.BOX_DIR}}
+
       - name: Destroy a box
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,14 @@ jobs:
 
       - name: Attach qcow2 disk
         run: |
+          ARCH=$(uname -m)
           qemu-img create -f qcow2 ${TEST_IMAGE} 1G
-          virsh attach-disk --domain ${BOX_DIR##*/}_${INSTANCE_NAME} --source ${TEST_IMAGE} --target vdb --driver qemu --subdriver qcow2 --targetbus virtio
+          [ ${ARCH} != "x86_64" ] && VIRSH_FLAGS="--config" || true
+          virsh attach-disk --domain ${BOX_DIR##*/}_${INSTANCE_NAME} --source ${TEST_IMAGE} --target vdb --driver qemu --subdriver qcow2 --targetbus virtio ${VIRSH_FLAGS}
+          if [ ${ARCH} != "x86_64" ]; then
+            vagrant reload $INSTANCE_NAME
+          fi
+
           cd $BOX_DIR && vagrant ssh ${{env.INSTANCE_NAME}} -c 'echo -e "n\np\n\n\n\nw" | sudo fdisk /dev/vdb'
 
       - name: Run tests (qcow2 disk)
@@ -111,17 +117,8 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
         timeout-minutes: 5
 
-      - name: Detach external drive
-        if: always()
-        run: |
-          if virsh domblklist ${BOX_DIR##*/}_${INSTANCE_NAME} --details | grep "file" | awk '{ print $NF }' | grep ${TEST_IMAGE} ; then
-              virsh detach-disk --domain ${BOX_DIR##*/}_${INSTANCE_NAME} ${TEST_IMAGE}
-          fi
-          rm -f ${TEST_IMAGE}
-
       - name: Upload artifacts
         # upload amd64 only, should work for both architectures
-        if: "${{ matrix.arch == 'amd64' }}"
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'AWS_SECRET_ACCESS_KEY='"'$AWS_SECRET_ACCESS_KEY'"' repobuild/upload.sh
           --source repobuild/artifacts/
           --bucket artifacts.assur.io
@@ -131,7 +128,9 @@ jobs:
 
       - name: Destroy a box
         if: always()
-        run: .github/scripts/destroy_box.sh
+        run: |
+          .github/scripts/destroy_box.sh
+          rm -f ${TEST_IMAGE}
 
   manifest:
     name: Artifacts manifest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,18 @@ jobs:
           ARCH=$(uname -m)
           qemu-img create -f qcow2 ${TEST_IMAGE} 1G
           [ ${ARCH} != "x86_64" ] && VIRSH_FLAGS="--config" || true
-          virsh attach-disk --domain ${BOX_DIR##*/}_${INSTANCE_NAME} --source ${TEST_IMAGE} --target vdb --driver qemu --subdriver qcow2 --targetbus virtio ${VIRSH_FLAGS}
+          virsh attach-disk --domain ${BOX_DIR##*/}_${INSTANCE_NAME} --source ${TEST_IMAGE} --target vdb --driver qemu --subdriver qcow2 --targetbus virtio ${VIRSH_FLAGS-}
+          # ARM64 boxes don't support "hot plug" w/o reboot
           if [ ${ARCH} != "x86_64" ]; then
-            vagrant reload $INSTANCE_NAME
+            virsh destroy --domain ${BOX_DIR##*/}_${INSTANCE_NAME}
+            virsh start --domain ${BOX_DIR##*/}_${INSTANCE_NAME}
+            while ! vagrant ssh ${INSTANCE_NAME} -c 'uptime'; do
+              echo "Waiting..."
+              sleep 1
+            done
           fi
-
-          cd $BOX_DIR && vagrant ssh ${{env.INSTANCE_NAME}} -c 'echo -e "n\np\n\n\n\nw" | sudo fdisk /dev/vdb'
+          vagrant ssh ${{env.INSTANCE_NAME}} -c 'echo -e "n\np\n\n\n\nw" | sudo fdisk /dev/vdb'
+        working-directory: ${{env.BOX_DIR}}
 
       - name: Run tests (qcow2 disk)
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh /dev/vdb1"
@@ -119,11 +125,16 @@ jobs:
 
       - name: Upload artifacts
         # upload amd64 only, should work for both architectures
-        run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'AWS_SECRET_ACCESS_KEY='"'$AWS_SECRET_ACCESS_KEY'"' repobuild/upload.sh
-          --source repobuild/artifacts/
-          --bucket artifacts.assur.io
-          --target /linux/elastio-snap/${SOURCE_BRANCH}/${GITHUB_RUN_NUMBER}/${PKG_TYPE}
-          --exclude *GPG-KEY'
+        run: |
+          excl_ptrn="*GPG-KEY"
+          # We have to avoid a race condition when package like elastio-snap-dkms_X.XX.XX-1debian11_all.deb is uploaded from
+          # 2 Debian 11 VMs amd64 and arm64 at the same time to the same location.
+          [ $(uname -m) != "x86_64" ] && [ -f /etc/debian_version ] && excl_ptrn=$excl_ptrn",*_all.deb" || true
+          vagrant ssh ${{env.INSTANCE_NAME}} -c 'AWS_SECRET_ACCESS_KEY='"'$AWS_SECRET_ACCESS_KEY'"' repobuild/upload.sh \
+            --source repobuild/artifacts/ \
+            --bucket artifacts.assur.io \
+            --target /linux/elastio-snap/${SOURCE_BRANCH}/${GITHUB_RUN_NUMBER}/${PKG_TYPE} \
+            --exclude '"'$excl_ptrn'"''
         working-directory: ${{env.BOX_DIR}}
 
       - name: Destroy a box

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,16 @@ jobs:
             distro: fedora36
           - arch: arm64
             distro: debian10
+          # FIXME: Debian 11 on ARM64 is not yet supported.
+          # See https://github.com/elastio/elastio-snap/issues/124 for more details.
+          #- arch: arm64
+          #  distro: debian11
+          # FIXME: CentOS 8 on ARM64 is not yet supported.
+          # See https://github.com/elastio/elastio-snap/issues/125 for more details.
+          #- arch: arm64
+          #  distro: centos8
           - arch: arm64
-            distro: debian11
-          - arch: arm64
-            distro: centos8
+            distro: ubuntu2204
 
     steps:
       - name: Checkout sources
@@ -72,6 +78,10 @@ jobs:
           sleep 5
         working-directory: ${{env.BOX_DIR}}
 
+      # Amazon 2 has installed devtoolset-8 which upgrades GCC from 7.3.1 to 8.3.1.
+      # The new gcc doesn't compile rpm packages properly, because of the /usr/lib/rpm/redhat/macros provided
+      # by the package system-rpm-config-9.1.0-76.amzn2.0.13.noarch. And this macros has compilation flags applicable
+      # for GCC 7 and already removed from GCC 8. The workaround is to disable devtoolset-8 on the next build step.
       - name: Remove devtoolset
         if: "${{ matrix.distro == 'amazon2' && matrix.arch == 'arm64' }}"
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'sudo rm /etc/profile.d/enable-llvm-toolset.sh'

--- a/src/configure-tests/symbol-tests
+++ b/src/configure-tests/symbol-tests
@@ -1,5 +1,10 @@
 sys_mount
 sys_umount
+__x64_sys_mount
+__x64_sys_umount
+__arm64_sys_mount
+__arm64_sys_umount
+__change_memory_common
 sys_oldumount
 sys_call_table
 kfree

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -5647,6 +5647,11 @@ static int hook_system_call_table(void)
 	system_call_table = find_sys_call_table();
 	if(!system_call_table){
 		LOG_ERROR(-ENOENT, "failed to locate system call table, persistence disabled");
+
+		if (!SYS_CALL_TABLE_ADDR) {
+			LOG_WARN("make sure that CONFIG_KALLSYMS_ALL is enabled");
+		}
+
 		return -ENOENT;
 	}
 
@@ -5908,7 +5913,6 @@ static int __init agent_init(void){
 		ret = hook_system_call_table();
 		if (ret) {
 			LOG_ERROR(ret, "couldn't hook the syscall table");
-			goto error;
 		}
 	}
 

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -5428,7 +5428,7 @@ static asmlinkage long umount_hook(char __user *name, int flags){
 
 	kfree(buff_dev_name);
 
-	ret = handle_bdev_mount_nowrite(buff_dev_name, flags, &idx);
+	ret = handle_bdev_mount_nowrite(name, flags, &idx);
 #ifdef USE_ARCH_MOUNT_FUNCS
 	sys_ret = orig_umount(regs);
 #else

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -5424,7 +5424,7 @@ static asmlinkage long umount_hook(char __user *name, int flags){
 	if(ret)
 		LOG_DEBUG("detected block device umount error: %d", ret);
 	else
-		LOG_DEBUG("detected block device umount: %s : %ld", buff_dev_name, flags);
+		LOG_DEBUG("detected block device umount: %s : %ld", buff_dev_name, (unsigned long) flags);
 
 	kfree(buff_dev_name);
 

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -1144,8 +1144,22 @@ static void **system_call_table = NULL;
 static struct lock_class_key sd_bio_compl_lkclass;
 #endif
 
+#if !SYS_MOUNT_ADDR
+#if __X64_SYS_MOUNT_ADDR || __ARM64_SYS_MOUNT_ADDR
+#define USE_ARCH_MOUNT_FUNCS
+#else
+#warning "No mount function found"
+#endif
+#endif
+
+#ifdef USE_ARCH_MOUNT_FUNCS
+static asmlinkage long (*orig_mount)(struct pt_regs *regs);
+static asmlinkage long (*orig_umount)(struct pt_regs *regs);
+#else
 static asmlinkage long (*orig_mount)(char __user *, char __user *, char __user *, unsigned long, void __user *);
-static asmlinkage long (*orig_umount)(char __user *, int);
+static asmlinkage long (*orig_umount)(char __user *name, int flags);
+#endif
+
 #ifdef HAVE_SYS_OLDUMOUNT
 static asmlinkage long (*orig_oldumount)(char __user *);
 #endif
@@ -5262,18 +5276,52 @@ static void post_umount_check(int dormant_ret, long umount_ret, unsigned int idx
 	LOG_DEBUG("post umount check succeeded");
 }
 
+#ifdef USE_ARCH_MOUNT_FUNCS
+static int mount_hook_extract_params(struct pt_regs *regs, char **dev_name, char **dir_name, unsigned long *flags)
+{
+	if (!regs || !dev_name ||
+			!dir_name || !flags)
+		return -1;
+
+#if defined(CONFIG_ARM64)
+	*dev_name = (char *) regs->regs[0];
+	*dir_name = (char *) regs->regs[1];
+	*flags = regs->regs[3];
+#elif defined(CONFIG_X86_64)
+	*dev_name = (char *) regs->di;
+	*dir_name = (char *) regs->si;
+	*flags = regs->r10;
+#endif
+	return 0;
+}
+
+static asmlinkage long mount_hook(struct pt_regs *regs){
+#else
 static asmlinkage long mount_hook(char __user *dev_name, char __user *dir_name, char __user *type, unsigned long flags, void __user *data){
+#endif
 	int ret;
 	int ret_dev;
 	int ret_dir;
 	long sys_ret;
 	unsigned int idx;
-	unsigned long real_flags = flags;
 	char *buff_dev_name = NULL;
 	char *buff_dir_name = NULL;
+	unsigned long real_flags;
 
-	//get rid of the magic value if its present
-	if((real_flags & MS_MGC_MSK) == MS_MGC_VAL) real_flags &= ~MS_MGC_MSK;
+#ifdef USE_ARCH_MOUNT_FUNCS
+	unsigned long flags;
+	char *dir_name;
+	char *dev_name;
+
+	ret = mount_hook_extract_params(regs, &dev_name, &dir_name, &flags);
+	if (ret) {
+		// should never happen
+		LOG_ERROR(ret, "couldn't extract mount params");
+		return -EOPNOTSUPP;
+	}
+#endif
+
+	real_flags = flags;
 
 	buff_dev_name = kmalloc(PATH_MAX, GFP_ATOMIC);
 	buff_dir_name = kmalloc(PATH_MAX, GFP_ATOMIC);
@@ -5284,55 +5332,110 @@ static asmlinkage long mount_hook(char __user *dev_name, char __user *dir_name, 
 			kfree(buff_dir_name);
 		return -ENOMEM;
 	}
-	ret_dev=copy_from_user(buff_dev_name,dev_name,PATH_MAX);
-	ret_dir=copy_from_user(buff_dir_name,dir_name,PATH_MAX);
+
+	ret_dev = copy_from_user(buff_dev_name, (char *) dev_name, PATH_MAX);
+	ret_dir = copy_from_user(buff_dir_name, (char *) dir_name, PATH_MAX);
+
 	if(ret_dev || ret_dir)
 		LOG_DEBUG("detected block device Get mount params error!");
 	else
 		LOG_DEBUG("detected block device mount: %s -> %s : 0x%lx", buff_dev_name,
 			buff_dir_name, real_flags);
-	kfree(buff_dev_name);
-	kfree(buff_dir_name);
+
+	//get rid of the magic value if its present
+	if((real_flags & MS_MGC_MSK) == MS_MGC_VAL) real_flags &= ~MS_MGC_MSK;
 
 	if(real_flags & (MS_BIND | MS_SHARED | MS_PRIVATE | MS_SLAVE | MS_UNBINDABLE | MS_MOVE) || ((real_flags & MS_RDONLY) && !(real_flags & MS_REMOUNT))){
 		//bind, shared, move, or new read-only mounts it do not affect the state of the driver
+#ifdef USE_ARCH_MOUNT_FUNCS
+		sys_ret = orig_mount(regs);
+#else
 		sys_ret = orig_mount(dev_name, dir_name, type, flags, data);
+#endif
 	}else if((real_flags & MS_RDONLY) && (real_flags & MS_REMOUNT)){
 		//we are remounting read-only, same as umounting as far as the driver is concerned
-		ret = handle_bdev_mount_nowrite(dir_name, 0, &idx);
+		ret = handle_bdev_mount_nowrite(buff_dir_name, 0, &idx);
+
+#ifdef USE_ARCH_MOUNT_FUNCS
+		sys_ret = orig_mount(regs);
+#else
 		sys_ret = orig_mount(dev_name, dir_name, type, flags, data);
-		post_umount_check(ret, sys_ret, idx, dir_name);
+#endif
+
+		post_umount_check(ret, sys_ret, idx, buff_dir_name);
 	}else{
 		//new read-write mount
+#ifdef USE_ARCH_MOUNT_FUNCS
+		sys_ret = orig_mount(regs);
+#else
 		sys_ret = orig_mount(dev_name, dir_name, type, flags, data);
-		if(!sys_ret) handle_bdev_mounted_writable(dir_name, &idx);
+#endif
+		if(!sys_ret) handle_bdev_mounted_writable(buff_dir_name, &idx);
 	}
+
+	kfree(buff_dev_name);
+	kfree(buff_dir_name);
 
 	LOG_DEBUG("mount returned: %ld", sys_ret);
 
 	return sys_ret;
 }
 
+#ifdef USE_ARCH_MOUNT_FUNCS
+static int umount_hook_extract_params(struct pt_regs *regs, char **dev_name, unsigned long *flags)
+{
+	if (!regs || !dev_name || !flags)
+		return -1;
+
+#if defined(CONFIG_ARM64)
+	*dev_name = (char *) regs->regs[0];
+	*flags = regs->regs[1];
+#elif defined(CONFIG_X86_64)
+	*dev_name = (char *) regs->di;
+	*flags = regs->si;
+#endif
+	return 0;
+}
+
+static asmlinkage long umount_hook(struct pt_regs *regs){
+#else
 static asmlinkage long umount_hook(char __user *name, int flags){
+#endif
 	int ret;
 	long sys_ret;
 	unsigned int idx;
 	char* buff_dev_name = NULL;
 
+#ifdef USE_ARCH_MOUNT_FUNCS
+	unsigned long flags;
+	char *name;
+
+	ret = umount_hook_extract_params(regs, &name, &flags);
+	if (ret) {
+		// should never happen
+		LOG_ERROR(ret, "couldn't extract umount params");
+		return -EOPNOTSUPP;
+	}
+#endif
+
 	buff_dev_name = kmalloc(PATH_MAX, GFP_ATOMIC);
 	if(!buff_dev_name) {
 		return -ENOMEM;
 	}
-	ret=copy_from_user(buff_dev_name, name, PATH_MAX);
+	ret = copy_from_user(buff_dev_name, name, PATH_MAX);
 	if(ret)
-		LOG_DEBUG("detected block device umount error:%d", ret);
+		LOG_DEBUG("detected block device umount error : %d", ret);
 	else
-		LOG_DEBUG("detected block device umount: %s : %d", buff_dev_name, flags);
-	kfree(buff_dev_name);
+		LOG_DEBUG("detected block device umount: %s : %ld", buff_dev_name, flags);
 
-	ret = handle_bdev_mount_nowrite(name, flags, &idx);
+	ret = handle_bdev_mount_nowrite(buff_dev_name, flags, &idx);
+#ifdef USE_ARCH_MOUNT_FUNCS
+	sys_ret = orig_umount(regs);
+#else
 	sys_ret = orig_umount(name, flags);
-	post_umount_check(ret, sys_ret, idx, name);
+#endif
+	post_umount_check(ret, sys_ret, idx, buff_dev_name);
+	kfree(buff_dev_name);
 
 	LOG_DEBUG("umount returned: %ld", sys_ret);
 
@@ -5358,7 +5461,6 @@ static asmlinkage long oldumount_hook(char __user *name){
 	kfree(buff_dev_name);
 
 	ret = handle_bdev_mount_nowrite(name, 0, &idx);
-	sys_ret = orig_oldumount(name);
 	post_umount_check(ret, sys_ret, idx, name);
 
 	LOG_DEBUG("oldumount returned: %ld", sys_ret);
@@ -5367,22 +5469,79 @@ static asmlinkage long oldumount_hook(char __user *name){
 }
 #endif
 
-//#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,22)
+static void **find_sys_call_table(void){
+	long long mount_address = 0;
+	long long umount_address = 0;
+	long long offset = 0;
+	void **sct;
+
+	if(!SYS_CALL_TABLE_ADDR)
+		return NULL;
+
+#ifndef USE_ARCH_MOUNT_FUNCS
+	mount_address = SYS_MOUNT_ADDR;
+	umount_address = SYS_UMOUNT_ADDR;
+#else
+#if __X64_SYS_MOUNT_ADDR
+	mount_address = __X64_SYS_MOUNT_ADDR;
+	umount_address = __X64_SYS_UMOUNT_ADDR;
+#else
+	mount_address = __ARM64_SYS_MOUNT_ADDR;
+	umount_address = __ARM64_SYS_UMOUNT_ADDR;
+#endif
+#endif
+
+	if (!mount_address || !umount_address)
+		return NULL;
+
+	offset = ((void *)kfree) - (void *)KFREE_ADDR;
+	sct = (void **)SYS_CALL_TABLE_ADDR + offset / sizeof(void **);
+
+	if(sct[__NR_mount] != (void **)mount_address + offset / sizeof(void **)) return NULL;
+	if(sct[__NR_umount2] != (void **)umount_address + offset / sizeof(void **)) return NULL;
+#ifdef HAVE_SYS_OLDUMOUNT
+	if(sct[__NR_umount] != (void **)SYS_OLDUMOUNT_ADDR + offset / sizeof(void **)) return NULL;
+#endif
+
+	LOG_DEBUG("system call table located at 0x%p", sct);
+
+	return sct;
+}
+
+#ifdef CONFIG_ARM64
+static int set_page_rw(unsigned long addr)
+{
+	int (*__change_memory_common)(unsigned long, unsigned long,
+			pgprot_t, pgprot_t) = (void *)__CHANGE_MEMORY_COMMON_ADDR;
+
+    vm_unmap_aliases();
+    return __change_memory_common(addr, PAGE_SIZE, __pgprot(PTE_WRITE), __pgprot(PTE_RDONLY));
+}
+
+static int set_page_ro(unsigned long addr)
+{
+	int (*__change_memory_common)(unsigned long, unsigned long,
+			pgprot_t, pgprot_t) = (void *)__CHANGE_MEMORY_COMMON_ADDR;
+
+    vm_unmap_aliases();
+    return __change_memory_common(addr, PAGE_SIZE, __pgprot(PTE_RDONLY), __pgprot(PTE_WRITE));
+}
+#endif
+
+#ifdef CONFIG_X86_64
+
 #ifndef X86_CR0_WP
 #define X86_CR0_WP (1UL << 16)
 #endif
 
 static inline void wp_cr0(unsigned long cr0) {
-#ifdef USE_BDOPS_SUBMIT_BIO
 	// Enabling/disabling approach with usage of the write_cr0 function stopped to work somewhere starting from the kernels 5.X (maybe 5.3)
 	// after this patch https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8dbec27a242cd3e2816eeb98d3237b9f57cf6232
-	// Hence there is a workaround.
-	// The USE_BDOPS_SUBMIT_BIO have to be replaced with something else if this workaround is necessary for some other 5.X kernels.
-	// Now it's used just for the 5.9+ kernels.
-	__asm__ __volatile__ ("mov %0, %%cr0": "+r" (cr0));
-#else
+	// Hence there is a workaround: if we couldn't reset the WP bit, just do this forcefuly without a native function
 	write_cr0(cr0);
-#endif
+	if (read_cr0() & X86_CR0_WP) {
+		__asm__ __volatile__ ("mov %0, %%cr0": "+r" (cr0));
+	}
 }
 
 static inline unsigned long disable_page_protection(void) {
@@ -5395,53 +5554,70 @@ static inline unsigned long disable_page_protection(void) {
 static inline void reenable_page_protection(unsigned long cr0) {
 	wp_cr0(cr0);
 }
-
-static void **find_sys_call_table(void){
-	long long offset;
-	void **sct;
-
-	if(!SYS_CALL_TABLE_ADDR || !SYS_MOUNT_ADDR || !SYS_UMOUNT_ADDR) return NULL;
-
-	offset = ((void *)kfree) - (void *)KFREE_ADDR;
-	sct = (void **)SYS_CALL_TABLE_ADDR + offset / sizeof(void **);
-
-	if(sct[__NR_mount] != (void **)SYS_MOUNT_ADDR + offset / sizeof(void **)) return NULL;
-	if(sct[__NR_umount2] != (void **)SYS_UMOUNT_ADDR + offset / sizeof(void **)) return NULL;
-#ifdef HAVE_SYS_OLDUMOUNT
-	if(sct[__NR_umount] != (void **)SYS_OLDUMOUNT_ADDR + offset / sizeof(void **)) return NULL;
 #endif
 
-	LOG_DEBUG("system call table located at 0x%p", sct);
-
-	return sct;
+/** generic function to manage system call table page permissions */
+static inline long syscall_mode_rw(void **syscall_table, int syscall_num)
+{
+#if defined(CONFIG_X86_64)
+	return disable_page_protection(); 
+#elif defined(CONFIG_ARM64)
+	return set_page_rw((unsigned long) (syscall_table + syscall_num));
+#else
+	return -1;
+#endif
 }
 
-#define set_syscall(sys_nr, orig_call_save, new_call) 		\
-	orig_call_save = system_call_table[sys_nr];				\
-	system_call_table[sys_nr] = new_call;
+/** generic function to manage system call table page permissions */
+static inline long syscall_mode_ro(void **syscall_table, int syscall_num, unsigned long flags)
+{
+#if defined(CONFIG_X86_64)
+	reenable_page_protection(flags);
+#elif defined(CONFIG_ARM64)
+	return set_page_ro((unsigned long) (syscall_table + syscall_num));
+#else
+	return -1;
+#endif
+	return 0;
+}
 
-#define restore_syscall(sys_nr, orig_call_save) system_call_table[sys_nr] = orig_call_save;
+static inline int syscall_set_hook(void **syscall_table,
+		int syscall_num, void **orig_hook, void *new_hook)
+{
+	long flags;
 
-static void restore_system_call_table(void){
-	unsigned long cr0;
+	flags = syscall_mode_rw(syscall_table, syscall_num);
+	if (flags == -1)
+		return -EOPNOTSUPP;
 
+	if (orig_hook)
+		*orig_hook = syscall_table[syscall_num];
+
+	syscall_table[syscall_num] = new_hook;
+	syscall_mode_ro(syscall_table, syscall_num, flags);
+
+	return 0;
+}
+
+static void restore_system_call_table(void)
+{
 	if(system_call_table){
 		LOG_DEBUG("restoring system call table");
-		//break back into the syscall table and replace the hooks we stole
+
 		preempt_disable();
-		cr0 = disable_page_protection();
-		restore_syscall(__NR_mount, orig_mount);
-		restore_syscall(__NR_umount2, orig_umount);
+		// break back into the syscall table and replace the hooks we stole
+		syscall_set_hook(system_call_table, __NR_mount, NULL, orig_mount);
+		syscall_set_hook(system_call_table, __NR_umount2, NULL, orig_umount);
 #ifdef HAVE_SYS_OLDUMOUNT
-		restore_syscall(__NR_umount, orig_oldumount);
+		syscall_set_hook(system_call_table, __NR_umount, NULL, orig_oldmount);
 #endif
-		reenable_page_protection(cr0);
 		preempt_enable();
 	}
 }
 
-static int hook_system_call_table(void){
-	unsigned long cr0;
+static int hook_system_call_table(void)
+{
+	int ret = 0;
 
 	//find sys_call_table
 	LOG_DEBUG("locating system call table");
@@ -5451,17 +5627,16 @@ static int hook_system_call_table(void){
 		return -ENOENT;
 	}
 
-	//break into the syscall table and steal the hooks we need
 	preempt_disable();
-	cr0 = disable_page_protection();
-	set_syscall(__NR_mount, orig_mount, mount_hook);
-	set_syscall(__NR_umount2, orig_umount, umount_hook);
+	//break into the syscall table and steal the hooks we need
+	ret = syscall_set_hook(system_call_table, __NR_mount, (void **) &orig_mount, mount_hook);
+	ret |= syscall_set_hook(system_call_table, __NR_umount2, (void **) &orig_umount, umount_hook);
 #ifdef HAVE_SYS_OLDUMOUNT
-	set_syscall(__NR_umount, orig_oldumount, oldumount_hook);
+	ret |= syscall_set_hook(system_call_table, __NR_umount, (void **) &orig_oldumount, oldumount_hook);
 #endif
-	reenable_page_protection(cr0);
 	preempt_enable();
-	return 0;
+
+	return ret;
 }
 
 /***************************BLOCK DEVICE DRIVER***************************/
@@ -5706,7 +5881,13 @@ static int __init agent_init(void){
 		goto error;
 	}
 
-	if(elastio_snap_may_hook_syscalls) (void)hook_system_call_table();
+	if(elastio_snap_may_hook_syscalls) {
+		ret = hook_system_call_table();
+		if (ret) {
+			LOG_ERROR(ret, "couldn't hook the syscall table");
+			return ret;
+		}
+	}
 
 	return 0;
 

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -5520,7 +5520,8 @@ static void **find_sys_call_table(void){
 static int set_page_rw(unsigned long addr)
 {
 	int (*__change_memory_common)(unsigned long, unsigned long,
-			pgprot_t, pgprot_t) = (void *)__CHANGE_MEMORY_COMMON_ADDR;
+			pgprot_t, pgprot_t) = (__CHANGE_MEMORY_COMMON_ADDR != 0) ?
+        (int (*)(unsigned long, unsigned long, pgprot_t, pgprot_t)) (__CHANGE_MEMORY_COMMON_ADDR + (long long)(((void *)kfree) - (void *)KFREE_ADDR)) : NULL;
 
 	if (!__change_memory_common) {
 		LOG_ERROR(-EFAULT, "error getting __change_memory_common address");
@@ -5534,7 +5535,8 @@ static int set_page_rw(unsigned long addr)
 static int set_page_ro(unsigned long addr)
 {
 	int (*__change_memory_common)(unsigned long, unsigned long,
-			pgprot_t, pgprot_t) = (void *)__CHANGE_MEMORY_COMMON_ADDR;
+			pgprot_t, pgprot_t) = (__CHANGE_MEMORY_COMMON_ADDR != 0) ?
+        (int (*)(unsigned long, unsigned long, pgprot_t, pgprot_t)) (__CHANGE_MEMORY_COMMON_ADDR + (long long)(((void *)kfree) - (void *)KFREE_ADDR)) : NULL;
 
 	if (!__change_memory_common) {
 		LOG_ERROR(-EFAULT, "error getting __change_memory_common address");

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -5491,9 +5491,11 @@ static void **find_sys_call_table(void){
 #if __X64_SYS_MOUNT_ADDR
 	mount_address = __X64_SYS_MOUNT_ADDR;
 	umount_address = __X64_SYS_UMOUNT_ADDR;
-#else
+#elif __ARM64_SYS_MOUNT_ADDR
 	mount_address = __ARM64_SYS_MOUNT_ADDR;
 	umount_address = __ARM64_SYS_UMOUNT_ADDR;
+#else
+#error "Architecture not supported"
 #endif
 #endif
 

--- a/src/genconfig.sh
+++ b/src/genconfig.sh
@@ -41,7 +41,6 @@ if [ ! -f "$SYSTEM_MAP_FILE" ] || [ $(cat "$SYSTEM_MAP_FILE" | wc -l) -lt 10 ]; 
 	fi
 fi
 
-
 echo "generating configurations for kernel-${KERNEL_VERSION}"
 
 rm -f $OUTPUT_FILE

--- a/tests/test_destroy.py
+++ b/tests/test_destroy.py
@@ -40,7 +40,7 @@ class TestDestroy(DeviceTestCase):
         self.assertFalse(os.path.exists(self.snap_device))
         self.assertIsNone(elastio_snap.info(self.minor))
 
-    @unittest.skipIf(int(platform.release().split(".")[0]) >= 5 and int(platform.release().split(".")[1]) >= 13, "Not fixed yet on the kernels newer than 5.13 (see #126)")
+    @unittest.skipIf(int(platform.release().split(".")[0]) >= 5 and int(platform.release().split(".")[1]) >= 13, "Not fixed yet on kernels newer than 5.13 (see #126)")
     def test_destroy_dormant_snapshot(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)
 
@@ -52,8 +52,7 @@ class TestDestroy(DeviceTestCase):
         self.assertFalse(os.path.exists(self.snap_device))
         self.assertIsNone(elastio_snap.info(self.minor))
 
-    @unittest.skipIf(int(platform.release().split(".")[0]) >= 5 and int(platform.release().split(".")[1]) >= 13, "Not fixed yet on the kernels newer than 5.13 (see #126)")
-    @unittest.skip("Broken since 4.17 (see #144)")
+    @unittest.skipIf(int(platform.release().split(".")[0]) >= 5 and int(platform.release().split(".")[1]) >= 13, "Not fixed yet on kernels newer than 5.13 (see #126)")
     def test_destroy_dormant_incremental(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)
         self.assertEqual(elastio_snap.transition_to_incremental(self.minor), 0)

--- a/tests/test_destroy.py
+++ b/tests/test_destroy.py
@@ -9,7 +9,7 @@
 import errno
 import os
 import unittest
-
+import platform
 import elastio_snap
 import util
 from devicetestcase import DeviceTestCase
@@ -40,6 +40,7 @@ class TestDestroy(DeviceTestCase):
         self.assertFalse(os.path.exists(self.snap_device))
         self.assertIsNone(elastio_snap.info(self.minor))
 
+    @unittest.skipIf(int(platform.release().split(".")[0]) >= 5 and int(platform.release().split(".")[1]) >= 13, "Not fixed yet on the kernels newer than 5.13 (see #126)")
     def test_destroy_dormant_snapshot(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)
 
@@ -51,6 +52,8 @@ class TestDestroy(DeviceTestCase):
         self.assertFalse(os.path.exists(self.snap_device))
         self.assertIsNone(elastio_snap.info(self.minor))
 
+    @unittest.skipIf(int(platform.release().split(".")[0]) >= 5 and int(platform.release().split(".")[1]) >= 13, "Not fixed yet on the kernels newer than 5.13 (see #126)")
+    @unittest.skip("Broken since 4.17 (see #144)")
     def test_destroy_dormant_incremental(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)
         self.assertEqual(elastio_snap.transition_to_incremental(self.minor), 0)

--- a/tests/test_destroy.py
+++ b/tests/test_destroy.py
@@ -40,7 +40,6 @@ class TestDestroy(DeviceTestCase):
         self.assertFalse(os.path.exists(self.snap_device))
         self.assertIsNone(elastio_snap.info(self.minor))
 
-    @unittest.skip("Broken since 4.17 (see #144)")
     def test_destroy_dormant_snapshot(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)
 
@@ -52,7 +51,6 @@ class TestDestroy(DeviceTestCase):
         self.assertFalse(os.path.exists(self.snap_device))
         self.assertIsNone(elastio_snap.info(self.minor))
 
-    @unittest.skip("Broken since 4.17 (see #144)")
     def test_destroy_dormant_incremental(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)
         self.assertEqual(elastio_snap.transition_to_incremental(self.minor), 0)

--- a/tests/util.py
+++ b/tests/util.py
@@ -57,4 +57,4 @@ def loop_destroy(loop):
 
 def mkfs(device):
     cmd = ["mkfs.ext4", "-F", device]
-    subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=20)
+    subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=30)

--- a/tests/util.py
+++ b/tests/util.py
@@ -57,4 +57,4 @@ def loop_destroy(loop):
 
 def mkfs(device):
     cmd = ["mkfs.ext4", "-F", device]
-    subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+    subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=20)


### PR DESCRIPTION
This PR **fixes** the issue with a syscall table location and provides **support for the `arm64` architecture**

From now on, elastio driver works on `x86` and `arm64` (`arm32` isn't supported so far)

Сloses #107
Сloses #120 

_Code changes:_
1. In latest kernels, `sys_mount` & `sys_umount` were changed to the architecture-dependent functions, f.e., `__x86_64_sys_mount` or `__arm64_sys_umount`.
2. These functions use `struct pt_regs * regs` as a parameter. Hence, `mount_hook` / `umount_hook()` functions have been refactored to work on different kernels
3. Macro `set_syscall` / `restore_syscall` have been rewritten to conform multi-architecture code structure. Underneath, it calls generic and arch functions to disable page protection, replaces the hook, and toggles the protection back:
`[generic] set_syscall`
`-> [generic] syscall_mode_rw`
`----> [arch] disable_page_protection` (x86) or `set_page_rw` (arm64)
4. Added arm64 to the build system and CI tests (Vagrantfile, ci.yml)
5. Amazon 2 has installed devtoolset-8 which upgrades GCC from 7.3.1 to 8.3.1. The new GCC doesn't compile rpm packages properly, because of the `/usr/lib/rpm/redhat/macros provided`. Hence, for Amazon 2 on arm64, we disable devtoolset
6. ARM64 boxes don't support qcow2 disk hotplug without a reboot. A restart of the box and waiting loop has been added
7. Removed architecture hardcode (`x86_64`) from the `collect_artifacts.sh`
8. Increased timeout for mkfs.ext4 on arm64 as the build machines are a bit slow

Known issues:
#124, #125, #126 