### PR TITLE
Change default library installation path and check permissions before build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PKGBUILDFLAGS := --define "_topdir $(BUILDDIR)" -ba --with devmode
 PKGBUILDROOT_CREATE_CMD = mkdir -p $(BUILDDIR)/DEBS $(BUILDDIR)/SDEBS $(BUILDDIR)/RPMS $(BUILDDIR)/SRPMS \
 			$(BUILDDIR)/SOURCES $(BUILDDIR)/SPECS $(BUILDDIR)/BUILD $(BUILDDIR)/BUILDROOT
 
-.PHONY: all check_root driver library-shared library-static library application application-shared utils clean install uninstall pkgclean pkgprep deb rpm
+.PHONY: all driver library-shared library-static library application application-shared utils clean install uninstall pkgclean pkgprep deb rpm
 
 all: check_root driver library application utils
 
@@ -28,7 +28,7 @@ ifneq ($(EUID),0)
 	@exit 1
 endif
 
-driver:
+driver: check_root
 	$(MAKE) -C src
 
 library-shared:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ export CCFLAGS = $(CFLAGS) -std=gnu99
 export PREFIX = /usr
 export BASE_DIR = $(abspath .)
 
+EUID := $(shell id -u -r)
+
 BUILDDIR := $(CURDIR)/pkgbuild
 
 # Flags to pass to debbuild/rpmbuild

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export CC = gcc
 export RM = rm -f
 CFLAGS ?= -Wall
 export CCFLAGS = $(CFLAGS) -std=gnu99
-export PREFIX = /usr/local
+export PREFIX = /usr
 export BASE_DIR = $(abspath .)
 
 BUILDDIR := $(CURDIR)/pkgbuild
@@ -16,9 +16,12 @@ PKGBUILDFLAGS := --define "_topdir $(BUILDDIR)" -ba --with devmode
 PKGBUILDROOT_CREATE_CMD = mkdir -p $(BUILDDIR)/DEBS $(BUILDDIR)/SDEBS $(BUILDDIR)/RPMS $(BUILDDIR)/SRPMS \
 			$(BUILDDIR)/SOURCES $(BUILDDIR)/SPECS $(BUILDDIR)/BUILD $(BUILDDIR)/BUILDROOT
 
-.PHONY: all driver library-shared library-static library application application-shared utils clean install uninstall pkgclean pkgprep deb rpm
+.PHONY: all check_root driver library-shared library-static library application application-shared utils clean install uninstall pkgclean pkgprep deb rpm
 
-all: driver library application utils
+all: check_root driver library application utils
+
+check_root:
+	@if ! [ "$(shell id -u)" = 0 ];then echo "You are not root, run this target as root, please"; exit 1; fi
 
 driver:
 	$(MAKE) -C src

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,10 @@ PKGBUILDROOT_CREATE_CMD = mkdir -p $(BUILDDIR)/DEBS $(BUILDDIR)/SDEBS $(BUILDDIR
 all: check_root driver library application utils
 
 check_root:
-	@if ! [ "$(shell id -u)" = 0 ];then echo "You are not root, run this target as root, please"; exit 1; fi
+ifneq ($(EUID),0)
+	@echo "Run as sudo or root."
+	@exit 1
+endif
 
 driver:
 	$(MAKE) -C src

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -3,9 +3,15 @@
 LIBNAME = libelastio-snap.so
 SOVER = 1
 SHARED_CCFLAGS = -fPIC -lc -shared -Wl,-soname,$(LIBNAME).$(SOVER)
-LIBDIR = $(PREFIX)/lib64
 
 SOURCES = libelastio-snap.c
+ifeq (,$(wildcard /etc/debian_version))
+	# rpm-based system
+	LIBDIR = $(PREFIX)/lib64
+else
+	# Debian-based system
+	LIBDIR = $(PREFIX)/lib
+endif
 
 .PHONY: all shared static install uninstall clean
 


### PR DESCRIPTION
1. No generic way to locate the user library paths was found for all distros we support
2. Properly, this should have been solved with Autoconf, which we don't use at the moment
3. But as we produce deb/rpm packages, this should not be a problem for users. Still, for developers, there's a possibility to specify the installation prefix with `sudo make PREFIX=<prefix>`
5. Apart from that, there should always be a common path for the libraries: /usr/lib64
6. Hence, I've replaced the prefix to `/usr`, making the default installation path of `/usr/lib64`
7. Apart from that, added permissions check to make sure that driver is compiled with root rights so that kernel functions are located properly in `kernel-configs.h`