### PR TITLE
Allow snap device to be readable after the cow file errors

### DIFF
--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -3276,7 +3276,8 @@ static int snap_trace_bio(struct snap_device *dev, struct bio *bio){
 	sector_t start_sect, end_sect;
 	unsigned int bytes, pages;
 
-	//if we don't need to cow this bio just call the real mrf normally
+	//if we don't need to cow or physical memory usage has exceeded threshold or
+	//	COW file state is failed, this bio just call the real mrf normally
 	if (!bio_needs_cow(bio, dev) || memory_is_too_low(dev) || tracer_read_cow_file_state(dev)) {
 		return elastio_snap_call_mrf(dev->sd_orig_mrf, bio);
 	}

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -1015,8 +1015,8 @@ struct snap_device{
 	unsigned long sd_cache_size; //maximum cache size (in bytes)
 	atomic_t sd_refs; //number of users who have this device open
 	atomic_t sd_fail_code; //failure return code
-	atomic_t sd_memory_state; //memory state to signal memory usage has exceeded threshold
-	atomic_t sd_cow_file_state; //cow file state to signal cow has exceeded max size
+	atomic_t sd_memory_fail_code; //memory failure return code to signal memory usage has exceeded threshold
+	atomic_t sd_cow_fail_state; //cow file failure return code
 	sector_t sd_sect_off; //starting sector of base block device
 	sector_t sd_size; //size of device in sectors
 	struct request_queue *sd_queue; //snap device request queue
@@ -1178,25 +1178,25 @@ static inline void tracer_set_fail_state(struct snap_device *dev, int error){
 	smp_mb();
 }
 
-static inline int tracer_read_memory_state(const struct snap_device *dev){
+static inline int tracer_read_memory_fail_state(const struct snap_device *dev){
 	smp_mb();
-	return atomic_read(&dev->sd_memory_state);
+	return atomic_read(&dev->sd_memory_fail_code);
 }
 
-static inline void tracer_set_memory_state(struct snap_device *dev, int error){
+static inline void tracer_set_memory_fail_state(struct snap_device *dev, int error){
 	smp_mb();
-	(void)atomic_cmpxchg(&dev->sd_memory_state, 0, error);
+	(void)atomic_cmpxchg(&dev->sd_memory_fail_code, 0, error);
 	smp_mb();
 }
 
-static inline int tracer_read_cow_file_state(const struct snap_device *dev){
+static inline int tracer_read_cow_fail_state(const struct snap_device *dev){
 	smp_mb();
-	return atomic_read(&dev->sd_cow_file_state);
+	return atomic_read(&dev->sd_cow_fail_state);
 }
 
-static inline void tracer_set_cow_file_state(struct snap_device *dev, int error){
+static inline void tracer_set_cow_fail_state(struct snap_device *dev, int error){
 	smp_mb();
-	(void)atomic_cmpxchg(&dev->sd_cow_file_state, 0, error);
+	(void)atomic_cmpxchg(&dev->sd_cow_fail_state, 0, error);
 	smp_mb();
 }
 
@@ -3101,12 +3101,12 @@ static int snap_cow_thread(void *data){
 				continue;
 			}
 
-			if (tracer_read_cow_file_state(dev) == 0)
+			if (tracer_read_cow_fail_state(dev) == 0)
 			{
 				ret = snap_handle_write_bio(dev, bio);
 				if (ret) {
 					LOG_ERROR(ret, "error handling write bio in kernel thread");
-					tracer_set_cow_file_state(dev, ret);
+					tracer_set_cow_fail_state(dev, ret);
 				}
 			}
 
@@ -3261,10 +3261,10 @@ static int memory_is_too_low(struct snap_device *dev) {
 		totalram = si.totalram;
 	}
 
-	ret = ((si_mem_available() * 100) / totalram) < LOW_MEMORY_FAIL_PERCENT ? -ENOMEM : tracer_read_memory_state(dev);
-	if (ret && tracer_read_memory_state(dev) == 0) {
+	ret = ((si_mem_available() * 100) / totalram) < LOW_MEMORY_FAIL_PERCENT ? -ENOMEM : tracer_read_memory_fail_state(dev);
+	if (ret && tracer_read_memory_fail_state(dev) == 0) {
 		LOG_WARN("physical memory usage has exceeded %d%% threshold. cow file update is stopped", (100 - LOW_MEMORY_FAIL_PERCENT));
-		tracer_set_memory_state(dev, ret);
+		tracer_set_memory_fail_state(dev, ret);
 	}
 	return ret;
 }
@@ -3278,7 +3278,7 @@ static int snap_trace_bio(struct snap_device *dev, struct bio *bio){
 
 	//if we don't need to cow or physical memory usage has exceeded threshold or
 	//	COW file state is failed, this bio just call the real mrf normally
-	if (!bio_needs_cow(bio, dev) || memory_is_too_low(dev) || tracer_read_cow_file_state(dev)) {
+	if (!bio_needs_cow(bio, dev) || memory_is_too_low(dev) || tracer_read_cow_fail_state(dev)) {
 		return elastio_snap_call_mrf(dev->sd_orig_mrf, bio);
 	}
 
@@ -3700,8 +3700,8 @@ static int __tracer_transition_tracing(struct snap_device *dev, struct block_dev
 static void __tracer_init(struct snap_device *dev){
 	LOG_DEBUG("initializing tracer");
 	atomic_set(&dev->sd_fail_code, 0);
-	atomic_set(&dev->sd_memory_state, 0);
-	atomic_set(&dev->sd_cow_file_state, 0);
+	atomic_set(&dev->sd_memory_fail_code, 0);
+	atomic_set(&dev->sd_cow_fail_state, 0);
 	bio_queue_init(&dev->sd_cow_bios);
 	bio_queue_init(&dev->sd_orig_bios);
 	sset_queue_init(&dev->sd_pending_ssets);
@@ -4504,10 +4504,10 @@ static void tracer_elastio_snap_info(const struct snap_device *dev, struct elast
 	info->state = dev->sd_state;
 	info->error = tracer_read_fail_state(dev);
 	if (info->error == 0) {
-		info->error = tracer_read_memory_state(dev);
+		info->error = tracer_read_memory_fail_state(dev);
 		if (info->error == 0)
 		{
-			info->error = tracer_read_cow_file_state(dev);
+			info->error = tracer_read_cow_fail_state(dev);
 		}
 	}
 	info->cache_size = (dev->sd_cache_size)? dev->sd_cache_size : elastio_snap_cow_max_memory_default;
@@ -4675,7 +4675,7 @@ static int ioctl_transition_inc(unsigned int minor){
 	//check that the device is not in the fail state
 	ret = tracer_read_fail_state(dev);
 	if (ret == 0) {
-		ret = tracer_read_cow_file_state(dev);
+		ret = tracer_read_cow_fail_state(dev);
 	}
 	if (ret) {
 		LOG_ERROR(ret, "device specified is in the fail state");

--- a/tests/test_transition_incremental.py
+++ b/tests/test_transition_incremental.py
@@ -53,7 +53,8 @@ class TestTransitionToIncremental(DeviceTestCase):
         # We want the former to happen, so make the OS sync everything.
 
         os.sync()
-        self.assertEqual(elastio_snap.transition_to_incremental(self.minor), errno.EINVAL)
+        err = elastio_snap.transition_to_incremental(self.minor)
+        self.assertTrue(err == errno.EINVAL or err == errno.EFBIG)
 
         snapdev = elastio_snap.info(self.minor)
         self.assertIsNotNone(snapdev)


### PR DESCRIPTION
Closes #129 