### PR TITLE
Update Vagrantfile to avoid deletion of the vagrant-libvirt network

### DIFF
--- a/.github/buildbox/Vagrantfile
+++ b/.github/buildbox/Vagrantfile
@@ -97,4 +97,12 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: $set_environment_variables, run: "always"
   config.vm.synced_folder "../../", "/home/elastio/elastio-snap", type: "rsync",
     rsync__args: ["-rLkz", "--delete", "--filter=:- .gitignore"], rsync__exclude: [".vagrant/"]
+
+  # This Vagrantfile can be used for the various box versions, even very old ones. Thus we need
+  # to define the 2 management_network variables here to prevent deletion of the 'vagrant-libvirt'
+  # network on the box destroy.
+  config.vm.provider :libvirt do |domain|
+    domain.management_network_name = "vagrant-libvirt"
+    domain.management_network_keep = "true"
+  end
 end

--- a/README.md
+++ b/README.md
@@ -31,21 +31,21 @@ The primary intended use case of Elastio-Snap is for backing up live Linux syste
 	elioctl setup-snapshot /dev/sda1 /.elastio 0
 ```
 
-This will create a snapshot of the root volume at `/dev/elastio0` with a backing COW file at `/.elastio`. This file must exist on the volume that will be snapshotted.
+This will create a snapshot of the root volume at `/dev/elastio-snap0` with a backing COW file at `/.elastio`. This file must exist on the volume that will be snapshotted.
 
 3) Copy the image off the block device:
 ```
 	dd if=/dev/elastio-snap0 of=/backups/sda1-bkp bs=1M
 ```
 
-`dd` is a standard image copying tool in linux. Here it simply copies the contents of the `/dev/elastio0` device to an image. Be careful when running this command as it can badly corrupt filesystems if used incorrectly. NEVER execute `dd` with the "of" parameter pointing to a volume that has important data on it. This can take a while to copy the entire volume. See the man page on `dd` for more details.
+`dd` is a standard image copying tool in linux. Here it simply copies the contents of the `/dev/elastio-snap0` device to an image. Be careful when running this command as it can badly corrupt filesystems if used incorrectly. NEVER execute `dd` with the "of" parameter pointing to a volume that has important data on it. This can take a while to copy the entire volume. See the man page on `dd` for more details.
 
 4) Put the snapshot into incremental mode:
 ```
 	elioctl transition-to-incremental 0
 ```
 
-This command requests the driver to move the snapshot (`/dev/elastio0`) to incremental mode. From this point on, the driver will only track the addresses of blocks that have changed (without the data itself). This mode is less system intensive, but is important for later when we wish to update the `/backups/sda1-bkp` to reflect a later snapshot of the filesystem.
+This command requests the driver to move the snapshot (`/dev/elastio-snap0`) to incremental mode. From this point on, the driver will only track the addresses of blocks that have changed (without the data itself). This mode is less system intensive, but is important for later when we wish to update the `/backups/sda1-bkp` to reflect a later snapshot of the filesystem.
 
 5) Continue using your system.
 After the initial backup, the driver will probably be left in incremental mode the vast majority of time.
@@ -63,7 +63,7 @@ This command requires the name of a new COW file to begin tracking changes again
 	update-img /dev/elastio-snap0 /.elastio /backups/sda1-bkp
 ```
 
-Here we can use the update-img tool included with the driver. It takes 3 parameters: a snapshot (`/dev/elastio0`), the list of changed blocks (`/.elastio` from step 1), and an original backup image (`/backups/sda1-bkp` created in step 3). It copies the blocks listed in the block list from the new snapshot to the existing image, effectively updating the image.
+Here we can use the update-img tool included with the driver. It takes 3 parameters: a snapshot (`/dev/elastio-snap0`), the list of changed blocks (`/.elastio` from step 1), and an original backup image (`/backups/sda1-bkp` created in step 3). It copies the blocks listed in the block list from the new snapshot to the existing image, effectively updating the image.
 
 8) Clean up the leftover file:
 ```


### PR DESCRIPTION
The purpose of this update is to use new devboxes which will not
remove vagrant-libvirt network from the build servers.

Also fixed mistakes in the README.md regarding the snapshot device name.

Related to https://github.com/elastio/elastio/issues/5539