### PR TITLE
Module refcnt becomes -1 on umount

### DIFF
--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -5217,19 +5217,19 @@ static int bdev_switch_ownership(const char __user *dir_name, int follow_flags, 
 
 	ret = user_path_at(AT_FDCWD, dir_name, lookup_flags, &path);
 	if(ret){
-		//error finding path
 		ret = -EINVAL;
+		LOG_DEBUG("error finding path");
 		goto out;
 	}else if(path.dentry != path.mnt->mnt_root){
-		//path specified isn't a mount point
 		ret = -ENODEV;
+		LOG_DEBUG("path specified isn't a mount point");
 		goto out;
 	}
 
 	bdev = path.mnt->mnt_sb->s_bdev;
 	if(!bdev){
-		//path specified isn't mounted on a block device
 		ret = -ENODEV;
+		LOG_DEBUG("path specified isn't mounted on a block device");
 		goto out;
 	}
 

--- a/tests/test_destroy.py
+++ b/tests/test_destroy.py
@@ -40,7 +40,6 @@ class TestDestroy(DeviceTestCase):
         self.assertFalse(os.path.exists(self.snap_device))
         self.assertIsNone(elastio_snap.info(self.minor))
 
-    @unittest.skipIf(int(platform.release().split(".")[0]) >= 5 and int(platform.release().split(".")[1]) >= 13, "Not fixed yet on kernels newer than 5.13 (see #126)")
     def test_destroy_dormant_snapshot(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)
 
@@ -52,7 +51,6 @@ class TestDestroy(DeviceTestCase):
         self.assertFalse(os.path.exists(self.snap_device))
         self.assertIsNone(elastio_snap.info(self.minor))
 
-    @unittest.skipIf(int(platform.release().split(".")[0]) >= 5 and int(platform.release().split(".")[1]) >= 13, "Not fixed yet on kernels newer than 5.13 (see #126)")
     def test_destroy_dormant_incremental(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)
         self.assertEqual(elastio_snap.transition_to_incremental(self.minor), 0)


### PR DESCRIPTION
This fix resolves the bug related to the dormant snapshot functionality:
  - at the first mount, the block device is owned by the parent driver
  - after the snapshot creation, we update ownership to the elastio driver
  - because of this, v5.13+ kernels did additional module_put() for our module at umount
The behavior above is the reason for this fix.

To resolve this, when active and umount, we switch the ownership back to the parent, hence
making the umount independent from the perspective of the elastio driver. When the device
is mounted again, re-gain ownership over it.

Apart from it, we do this to prevent the kernel from freeing our block_device_operations installed (f.e, if the device is removed from the system)

Closes #134 