### PR TITLE
Enable Debian 11 tests on arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,8 @@ jobs:
             arch: arm64
           - distro: debian10
             arch: arm64
-          # FIXME: Debian 11 on ARM64 is not yet supported.
-          # See https://github.com/elastio/elastio-snap/issues/124 for more details.
-          #- distro: debian11
-          #  arch: arm64
+          - distro: debian11
+            arch: arm64
           - distro: fedora35
             arch: arm64
           - distro: fedora36

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
           sleep 5
         working-directory: ${{env.BOX_DIR}}
 
+      - name: Download debug package for Debian 11
+        if: "${{ matrix.distro == 'debian11' && matrix.arch == 'arm64' }}"
+        run: |
+          vagrant ssh ${{env.INSTANCE_NAME}} -c '
+            sudo apt-get install -y linux-image-$(uname -r)-dbg' || true
+          sleep 5
+        working-directory: ${{env.BOX_DIR}}
       # Amazon 2 has installed devtoolset-8 which upgrades GCC from 7.3.1 to 8.3.1.
       # The new gcc doesn't compile rpm packages properly, because of the /usr/lib/rpm/redhat/macros provided
       # by the package system-rpm-config-9.1.0-76.amzn2.0.13.noarch. And this macros has compilation flags applicable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
           sleep 5
         working-directory: ${{env.BOX_DIR}}
 
+      # Please refer to https://github.com/elastio/devboxes/pull/230
       - name: Download debug package for Debian 11
         if: "${{ matrix.distro == 'debian11' && matrix.arch == 'arm64' }}"
         run: |
@@ -83,6 +84,7 @@ jobs:
             sudo apt-get install -y linux-image-$(uname -r)-dbg' || true
           sleep 5
         working-directory: ${{env.BOX_DIR}}
+
       # Amazon 2 has installed devtoolset-8 which upgrades GCC from 7.3.1 to 8.3.1.
       # The new gcc doesn't compile rpm packages properly, because of the /usr/lib/rpm/redhat/macros provided
       # by the package system-rpm-config-9.1.0-76.amzn2.0.13.noarch. And this macros has compilation flags applicable

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -221,8 +221,8 @@ BuildArch:       noarch
 %endif
 
 %if 0%{?debian}
-%if ( "%{_arch}" != "x86_64" && "%{_arch}" != "amd64" ) && ( 0%{?debian} == 11 )
-Requires:        linux-image-`uname -r`-dbg
+%if ( "%{_arch}" != "x86_64" && "%{_arch}" != "amd64" ) && ( %{debian} == 11 )
+Requires:        linux-image-%(uname -r)-dbg
 %endif
 %endif
 

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -220,6 +220,12 @@ Group:           System Environment/Kernel
 BuildArch:       noarch
 %endif
 
+%if 0%{?debian}
+%if ( "%{_arch}" != "x86_64" && "%{_arch}" != "amd64" ) && ( 0%{?debian} == 11 )
+Requires:        linux-image-`uname -r`-dbg
+%endif
+%endif
+
 %if 0%{?rhel} >= 6 || 0%{?fedora} >= 23 || 0%{?suse_version} >= 1315
 Requires(preun): dkms >= 2.3
 Requires:        dkms >= 2.3

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -222,6 +222,7 @@ BuildArch:       noarch
 
 %if 0%{?debian}
 %if ( "%{_arch}" != "x86_64" && "%{_arch}" != "amd64" ) && ( %{debian} == 11 )
+# Please refer to https://github.com/elastio/devboxes/pull/230
 Requires:        linux-image-%(uname -r)-dbg
 %endif
 %endif

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -222,6 +222,15 @@ BuildArch:       noarch
 
 %if 0%{?debian}
 %if ( "%{_arch}" != "x86_64" && "%{_arch}" != "amd64" ) && ( %{debian} == 11 )
+
+# By default, on arm64, Debian 11 is provided with the kernel with
+# some symbols absent AND with without a System.map file. This makes
+# the elastio-snap driver work without sys_call_table hooking support.
+#
+# As a compromise solution, we install linux-image-$(uname -r)-dbg
+# to make it work properly. This package adds System.map and makes
+# it possible to fetch the address of the system call table
+#
 # Please refer to https://github.com/elastio/devboxes/pull/230
 Requires:        linux-image-%(uname -r)-dbg
 %endif


### PR DESCRIPTION
 - Updated ci.yml to download `linux-image-$(uname -r)-dbg`
 - Updated `elastio-snap.spec` to add the abovementioned package as a dependency

See https://github.com/elastio/devboxes/pull/230 for more details

Closes #124