### PR TITLE
Fix module compilation on Linux kernel 5.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
         run: |
           vagrant ssh ${{env.INSTANCE_NAME}} -c '
             if $(which apt-get >/dev/null 2>&1); then
+              sudo apt-get update
               sudo apt-get install -y lvm2 mdadm
             else
               # Fedora has rather weak mirrors. But we do not want to have failing builds because of this.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,22 @@
 # elastio-snap INSTALL
 
 ## From Repositories
-Elastio Software Inc. provides repositories for x86_64 editions of the RHEL/CentOS starting from the version 7, Amazon Linux 2, Fedora 31 and newer, Debian 8 and newer, and Ubuntu LTS starting from the version 16.04.
-We recommend that you install the kernel module from Elastio's repositories.
+Elastio Software Inc. provides repositories for the RHEL/CentOS starting from the version 7, Amazon Linux 2, Fedora 31 and newer, Debian 8 and newer, and Ubuntu LTS starting from the version 16.04.  
+We recommend that you install the kernel module from Elastio's repositories.  
+
+Elastio provides repositories for the following Linux distributions and architectures:  
+
+|             Distro Name            |  Distro Ver | x86_64 | aarch64 |
+|:----------------------------------:|------------:|:------:|:-------:|
+| RHEL/CentOS                        |           7 | +      | -       |
+| RHEL/CentOS/Alma Linux/Rocky Linux |           8 | +      | +       |
+| Amazon Linux                       |           2 | +      | +       |
+| Fedora                             |       31-34 | +      | -       |
+|                                    |       35-36 | +      | +       |
+| Debian                             |         8-9 | +      | -       |
+|                                    |       10-11 | +      | +       |
+| Ubuntu                             | 16.04-18.04 | +      | -       |
+|                                    | 20.04-22.04 | +      | +       |
 
 ### Repository package installation for RPM-based systems
 
@@ -48,9 +62,9 @@ sudo yum install kernel-devel-$(uname -r) kernel-devel dkms-elastio-snap elastio
 
 ### Repository package installation for DEB-based systems
 
-#### Debian / Ubuntu LTS
+#### Debian 8 - 11 / Ubuntu 16.04 - 21.10
 The repository install package `elastio-repo` is available for Debian 8 (jessie) and newer.
-The same packages are applicable for Ubuntu LTS starting from 16.04 (xenial) and newer.
+The same packages are applicable for Ubuntu starting from 16.04 (xenial) and newer.
 ```bash
 # Install prerequisites. This is not necessary in the most cases except pure docker.
 sudo apt-get update
@@ -64,6 +78,18 @@ debian_ver=$(grep VERSION_ID /etc/os-release | tr -cd [0-9])
 # Download repo package and install it
 wget https://repo.assur.io/master/linux/deb/Debian/${debian_ver}/pool/elastio-repo_0.0.2-1debian${debian_ver}_all.deb
 sudo dpkg -i elastio-repo_0.0.2-1debian${debian_ver}_all.deb
+sudo apt-get update
+```
+#### Ubuntu 22.04
+The `elastio-repo` repository package is available for Ubuntu 22.04. This is a separate package for a separate repository, and not the same as for Debian 11, as it was for older versions of Debian/Ubuntu.
+```bash
+# Install prerequisites. This is not necessary in the most cases except pure docker.
+sudo apt-get update
+sudo apt-get install wget gnupg
+
+# Download repo package and install it
+wget https://repo.assur.io/master/linux/deb/Ubuntu/2204/pool/elastio-repo_0.0.2-1ubuntu22.04_all.deb
+sudo dpkg -i elastio-repo_0.0.2-1ubuntu22.04_all.deb
 sudo apt-get update
 ```
 

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -106,7 +106,7 @@
 
 
 Name:            elastio-snap
-Version:         0.10.17
+Version:         0.11.0
 Release:         1%{?dist}
 Summary:         Kernel module and utilities for enabling low-level live backups
 Vendor:          Elastio Software, Inc.
@@ -599,6 +599,21 @@ rm -rf %{buildroot}
 
 
 %changelog
+
+* Wed Aug 3 2022 Eugene Kovalenko <ikovalenko@elastio.com> - 0.11.0
+- Added support of Linux kernel 5.18 as on Fedora 36
+
+* Fri Jul 22 2022 Stanislav Barantsev <sbarantsev@elastio.com>
+- Fixed data corruption if bio request was split (LVM/RAID)
+
+* Fri Jul 15 2022 Eugene Kovalenko <ikovalenko@elastio.com>
+- Added support for LVM and software RAID on Linux kernels 5.8+
+- Modified tests to cover ext2/3/4, XFS filesystems
+
+* Fri Jun 10 2022 Stanislav Barantsev <sbarantsev@elastio.com>
+- Fixed syscall table location and dormant snapshots functionality after umount/mount
+- Added support of arm64 architecture
+- Fixed default library installation path and added permissions check before build
 
 * Fri May 20 2022 Alex Sereda <asereda@elastio.com> - 0.10.17
 - Add package repositories for Fedora 36 and Ubuntu 22.04

--- a/src/configure-tests/feature-tests/bio_alloc_bioset_5.c
+++ b/src/configure-tests/feature-tests/bio_alloc_bioset_5.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+// 5.18 <= kernel_version
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct bio_set bs;
+	struct bio *new_bio;
+	struct block_device bdev;
+
+	new_bio = bio_alloc_bioset(&bdev, 0, 0, GFP_NOIO, &bs);
+}

--- a/src/elastio-snap.h
+++ b/src/elastio-snap.h
@@ -15,7 +15,7 @@
 #include <linux/ioctl.h>
 #include <linux/limits.h>
 
-#define ELASTIO_SNAP_VERSION "0.10.15"
+#define ELASTIO_SNAP_VERSION "0.11.0"
 #define ELASTIO_IOCTL_MAGIC 'A' // 0x41
 
 struct setup_params{

--- a/src/includes.h
+++ b/src/includes.h
@@ -11,7 +11,15 @@
 #include <linux/module.h>
 #include <linux/moduleparam.h>
 #include <linux/blkdev.h>
-#include <linux/genhd.h>
+// 'genhd.h' has been removed and 'gendisk' struct has been moved to the 'blkdev.h' in the kernel 5.18.
+// Old compilers may not have '__has_include' macros, but 'genhd.h' exists on those systems.
+#if defined __has_include
+#	if __has_include (<linux/genhd.h>)
+#		include <linux/genhd.h>
+#	endif
+#else
+#	include <linux/genhd.h>
+#endif
 #include <linux/kthread.h>
 #include <linux/miscdevice.h>
 #include <linux/proc_fs.h>

--- a/src/includes.h
+++ b/src/includes.h
@@ -12,13 +12,13 @@
 #include <linux/moduleparam.h>
 #include <linux/blkdev.h>
 // 'genhd.h' has been removed and 'gendisk' struct has been moved to the 'blkdev.h' in the kernel 5.18.
-// Old compilers may not have '__has_include' macros, but 'genhd.h' exists on those systems.
+// Old compilers may not have '__has_include' macro, but 'genhd.h' exists on those systems.
 #if defined __has_include
-#	if __has_include (<linux/genhd.h>)
-#		include <linux/genhd.h>
-#	endif
+# if __has_include (<linux/genhd.h>)
+#  include <linux/genhd.h>
+# endif
 #else
-#	include <linux/genhd.h>
+# include <linux/genhd.h>
 #endif
 #include <linux/kthread.h>
 #include <linux/miscdevice.h>


### PR DESCRIPTION
**Fixed 2 compilation errors on 5.18**
1. `genhd.h` has been removed and `gendisk` struct has been  moved to
   the `blkdev.h` in the kernel 5.18. Used macros `__has_include` as an
   easiest fix. Old compilers may not have this macros, but `genhd.h`
   exists on those systems.
2. `bio_alloc_bioset` function now takes 5 arguments instead of 3.
   Added compat for this function.

Closes #152 

**_Additional changes:_**
- **Added info about `aarch64` support into INSTALL.md**
  Added "support platform matrix" into the same document and
  added info about installation on Ubuntu 22.04.
- **Bumped new version**
  The version has been increased from `0.10.17` to `0.11.0` due to
  major changes in the driver, such as `aarch64` support, fixes for the
  dormant snapshots functionality, LVM/raid support and recent
  stability fixes etc. The major changes since last version update were
  listed in the change log.
- **Fixed installation of lvm2 and mdadm on Debian in some cases**
  `apt-get update` was missing before `apt-get install`. And this time,
  Debian 11 was unable to properly install packages without updating
  the repositories information.