### PR TITLE
Fix driver stuck on ext4 raid1 volume on Debian 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,9 +183,8 @@ jobs:
         timeout-minutes: 1
 
       - name: Run tests on RAID (loop device)
-        # FIXME: Enable tests on Debian 9 after resolution of #146.
-        # And Debian 8 has reached EOL and has no mdadm tools installed.
-        if: "${{ matrix.distro != 'debian8' && matrix.distro != 'debian9' }}"
+        # Debian 8 has reached EOL and has no mdadm tools installed.
+        if: "${{ matrix.distro != 'debian8' }}"
         run: |
           for fs in ${FS[*]}; do
             vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh -f $fs --raid"
@@ -259,9 +258,8 @@ jobs:
         timeout-minutes: 1
 
       - name: Run tests on RAID (qcow2 disks)
-        # FIXME: Enable tests on Debian 9 after resolution of #146.
-        # And Debian 8 has reached EOL and has no mdadm tools installed.
-        if: "${{ matrix.distro != 'debian8' && matrix.distro != 'debian9' }}"
+        # Debian 8 has reached EOL and has no mdadm tools installed.
+        if: "${{ matrix.distro != 'debian8' }}"
         run: |
           for fs in ${FS[*]}; do
             vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh -d /dev/vdb1 -d /dev/vdc1 -f $fs --raid"


### PR DESCRIPTION
TL;DR
==
This is a reflection of fix 49826d1 recently made by @skypodolsky
for the LVM/RAID setups and driver stuck in the loop of the
`snap_handle_write_bio` function. This time the same fix is applied for
the read bios in the `snap_handle_read_bio` function.

Long description of the problem
==
An investigation was started from the hung of the `test_modify_origin`
unit-test on Debian 9 with Linux kernel 4.9 on volume `raid1` and `ext4`
file system.
The test contains the following steps:
1. setup snapshot of the raid volume
2. do some writes on the original volume
3. os.sync()
4. mount snapshot device
5. ...

The 4th operation led to a hang of the `mount` operation. Interesting
detail, the hang was not reproducible without `os.sync()` in the test or
on `xfs` fs (because `xfs` doesn't honour sync operation).
The `mount` operation performs reads from the device. And in our case we
had infinite iterations inside of the `bio_for_each_segment` -> `while`
loop in the `snap_handle_read_bio` function. And `snap_cow_thread` was
loading 1 core for 100%. Usage of the `bio_for_each_segment_all` allows
to iterate via all segments of the bio and fix this problem.
Another interesting point: potentially this bug may occur with different
kernel versions in cases where the read bio is split into multiple
segments. But the most favorable conditions for this turned out to be
precisely after the sync operation before reading (mount call) on
kernel 4.9 with raid1.

Resolves #146