### PR TITLE
Fix kernel panic on snapshot destroy for a partition

### DIFF
--- a/tests/devicetestcase.py
+++ b/tests/devicetestcase.py
@@ -19,9 +19,9 @@ class DeviceTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.minor = randint(0, 23)
-        r=[]
-        cls.backing_stores=[]
-        cls.devices=[]
+        seeds = []
+        cls.backing_stores = []
+        cls.devices = []
 
         cls.kmod = kmod.Module("../src/elastio-snap.ko")
         cls.kmod.load(debug=1)
@@ -37,10 +37,10 @@ class DeviceTestCase(unittest.TestCase):
                 # And then mdadm will fail to create a mirror from these "2 different" loop devices, because 2nd will always race 'device busy' error.
                 # So, let's verify the difference of these random numbers )
                 while True:
-                    ra = randint(0, 999)
-                    if not ra in r: break
-                r.append(ra)
-                cls.backing_stores.append("/tmp/disk_{0:03d}.img".format(r[i]))
+                    r = randint(0, 999)
+                    if not r in seeds: break
+                seeds.append(r)
+                cls.backing_stores.append("/tmp/disk_{0:03d}.img".format(seeds[i]))
                 util.dd("/dev/zero", cls.backing_stores[i], 256, bs="1M")
                 cls.devices.append(util.loop_create(cls.backing_stores[i]))
 

--- a/tests/devicetestcase_multipart.py
+++ b/tests/devicetestcase_multipart.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+#
+# Copyright (C) 2020 Elastio Software Inc.
+#
+
+import os
+import subprocess
+import unittest
+
+import kmod
+import util
+
+from random import randint
+
+@unittest.skipUnless(os.geteuid() == 0, "Must be run as root")
+#@unittest.skipUnless(os.getenv('TEST_DEVICES'), "This testcase works just with the internal loopback devices for now")
+class DeviceTestCaseMultipart(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # For now let's hardcode 2 partitions
+        cls.part_count = 2
+        cls.minors = []
+        cls.minors.append(randint(0, 23))
+        for i in range(cls.part_count):
+            # Unexpectedly randint can generate 2 same numbers in a row.
+            # So, let's verify the difference of the random numbers.
+            while True:
+                r = randint(0, 23)
+                if not r in cls.minors: break
+            cls.minors.append(r)
+
+        cls.kmod = kmod.Module("../src/elastio-snap.ko")
+        cls.kmod.load(debug=1)
+
+        cls.backing_store = ("/tmp/disk_{0:03d}.img".format(cls.minors[0]))
+        util.dd("/dev/zero", cls.backing_store, 256, bs="1M")
+
+        cls.device = util.loop_create(cls.backing_store, cls.part_count)
+        cls.devices = []
+        cls.devices += util.get_partitions(cls.device)
+
+        cls.mounts = []
+        cls.fs = os.getenv('TEST_FS', 'ext4')
+        for i in range(cls.part_count):
+            util.mkfs(cls.devices[i], cls.fs)
+            cls.mounts.append("/tmp/elastio-snap_{0:03d}".format(cls.minors[i]))
+            os.makedirs(cls.mounts[i], exist_ok=True)
+            util.mount(cls.devices[i], cls.mounts[i])
+
+    @classmethod
+    def tearDownClass(cls):
+        for mount in cls.mounts:
+            util.unmount(mount)
+            os.rmdir(mount)
+
+        util.loop_destroy(cls.device)
+        os.unlink(cls.backing_store)
+
+        cls.kmod.unload()

--- a/tests/devicetestcase_multipart.py
+++ b/tests/devicetestcase_multipart.py
@@ -15,6 +15,7 @@ from random import randint
 
 @unittest.skipUnless(os.geteuid() == 0, "Must be run as root")
 @unittest.skipIf(os.getenv('TEST_DEVICES'), "Multipart testcase works now just with the internal loopback devices")
+@unittest.skipIf(os.getenv('LVM') or os.getenv('RAID'), "Multipart testcase does not support LVM/raid devices creation")
 class DeviceTestCaseMultipart(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -43,7 +44,7 @@ class DeviceTestCaseMultipart(unittest.TestCase):
         cls.fs = os.getenv('TEST_FS', 'ext4')
         for i in range(cls.part_count):
             util.mkfs(cls.devices[i], cls.fs)
-            cls.mounts.append("/tmp/elastio-snap_{0:03d}".format(cls.minors[i]))
+            cls.mounts.append("/tmp/elio-dev-mnt_{0:03d}".format(cls.minors[i]))
             os.makedirs(cls.mounts[i], exist_ok=True)
             util.mount(cls.devices[i], cls.mounts[i])
 

--- a/tests/devicetestcase_multipart.py
+++ b/tests/devicetestcase_multipart.py
@@ -14,14 +14,13 @@ import util
 from random import randint
 
 @unittest.skipUnless(os.geteuid() == 0, "Must be run as root")
-#@unittest.skipUnless(os.getenv('TEST_DEVICES'), "This testcase works just with the internal loopback devices for now")
+@unittest.skipIf(os.getenv('TEST_DEVICES'), "Multipart testcase works now just with the internal loopback devices")
 class DeviceTestCaseMultipart(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # For now let's hardcode 2 partitions
         cls.part_count = 2
         cls.minors = []
-        cls.minors.append(randint(0, 23))
         for i in range(cls.part_count):
             # Unexpectedly randint can generate 2 same numbers in a row.
             # So, let's verify the difference of the random numbers.

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -25,7 +25,7 @@ class TestMultipart(DeviceTestCaseMultipart):
         for i in range(self.part_count):
             self.cow_full_paths.append("{}/{}".format(self.mounts[i], self.cow_file))
             self.snap_devices.append("/dev/elastio-snap{}".format(self.minors[i]))
-            self.snap_mounts.append("/tmp/elastio-snap{}".format(self.minors[i]))
+            self.snap_mounts.append("/tmp/elio-snap-mnt{0:03d}".format(self.minors[i]))
             os.makedirs(self.snap_mounts[i], exist_ok=True)
             self.addCleanup(os.rmdir, self.snap_mounts[i])
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-only
+
+#
+# Copyright (C) 2020 Elastio Software Inc.
+#
+
+import errno
+import os
+import subprocess
+import time
+import unittest
+from random import randint
+
+import elastio_snap
+import util
+from devicetestcase_multipart import DeviceTestCaseMultipart
+
+class TestMultipart(DeviceTestCaseMultipart):
+    def setUp(self):
+        self.cow_file = "cow.snap"
+        self.cow_full_paths = []
+        self.snap_devices = []
+        self.snap_mounts = []
+        for i in range(self.part_count):
+            self.cow_full_paths.append("{}/{}".format(self.mounts[i], self.cow_file))
+            self.snap_devices.append("/dev/elastio-snap{}".format(self.minors[i]))
+            self.snap_mounts.append("/tmp/elastio-snap{}".format(self.minors[i]))
+            os.makedirs(self.snap_mounts[i], exist_ok=True)
+
+
+    def test_setup_2_volumes_same_disk(self):
+        for i in range(self.part_count):
+            self.assertEqual(elastio_snap.setup(self.minors[i], self.devices[i], self.cow_full_paths[i]), 0)
+            #self.addCleanup(elastio_snap.destroy, self.minors[i])
+
+            self.assertTrue(os.path.exists(self.snap_devices[i]))
+
+            snapdev = elastio_snap.info(self.minors[i])
+            self.assertIsNotNone(snapdev)
+
+            self.assertEqual(snapdev["error"], 0)
+            self.assertEqual(snapdev["state"], 3)
+            self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
+            self.assertEqual(snapdev["bdev"], self.devices[i])
+            self.assertEqual(snapdev["version"], 1)
+
+        # Destroy 2nd snapshot device first
+        self.assertEqual(elastio_snap.destroy(self.minors[-1]), 0)
+
+        # Write to the 2nd device
+        testfile = "{}/testfile".format(self.mounts[-1])
+        with open(testfile, "w") as f:
+            f.write("The quick brown fox")
+
+        self.addCleanup(os.remove, testfile)
+        os.sync()
+        time.sleep(5)
+
+        # Destroy 1st snapshot device finally
+        self.assertEqual(elastio_snap.destroy(self.minors[0]), 0)
+
+    def test_modify_origins(self):
+        for i in range(self.part_count):
+            testfile = "{}/testfile".format(self.mounts[i])
+            snapfile = "{}/testfile".format(self.snap_mounts[i])
+
+            with open(testfile, "w") as f:
+                f.write("The quick brown fox")
+
+            self.addCleanup(os.remove, testfile)
+            os.sync()
+            md5_orig = util.md5sum(testfile)
+
+            self.assertEqual(elastio_snap.setup(self.minors[i], self.devices[i], self.cow_full_paths[i]), 0)
+            self.addCleanup(elastio_snap.destroy, self.minors[i])
+
+            with open(testfile, "w") as f:
+                f.write("jumps over the lazy dog")
+
+            os.sync()
+            # TODO: norecovery option, probably, should not be here after the fix of the elastio/elastio-snap#63
+            opts = "nouuid,norecovery,ro" if (self.fs == "xfs") else "ro"
+            util.mount(self.snap_devices[i], self.snap_mounts[i], opts)
+            self.addCleanup(util.unmount, self.snap_mounts[i])
+            self.addCleanup(os.rmdir, self.snap_mounts[i])
+
+            md5_snap = util.md5sum(snapfile)
+            self.assertEqual(md5_orig, md5_snap)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -7,6 +7,7 @@
 
 import errno
 import os
+import platform
 import subprocess
 import time
 import unittest
@@ -77,6 +78,7 @@ class TestMultipart(DeviceTestCaseMultipart):
             self.assertEqual(elastio_snap.destroy(self.minors[i]), 0)
 
 
+    @unittest.skipIf(os.getenv('TEST_FS') == "xfs" and  platform.release().rsplit(".", 1)[0] == "4.18.0-383.el8", "Broken on CentOS 8 with kernel 4.18.0-383.el8 and XFS. See #159")
     def test_multipart_modify_origins(self):
         for i in range(self.part_count):
             testfile = "{}/testfile".format(self.mounts[i])

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -84,6 +84,9 @@ class TestSetup(DeviceTestCase):
 
         cmd = ["findmnt", "/", "-n", "-o", "SOURCE"]
         device = subprocess.check_output(cmd, timeout=10, shell=False).rstrip().decode("utf-8")
+        # Convert LVM logical volume name (if it is) to the kernel bdev name
+        cmd = ["readlink", "-f", device]
+        device = subprocess.check_output(cmd, timeout=10).rstrip().decode("utf-8")
         snap_device = "/dev/elastio-snap{}".format(minor)
         cow_file = "cow"
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -85,8 +85,11 @@ def loop_create(path, part_count = 0):
     part_type = "primary"
     part_size_percent = 100 // part_count
     cmd = ["parted", "--script", "--align", "optimal", loopdev, "mklabel", "gpt"]
-    for i in range(0, 100, part_size_percent):
-        cmd.append("mkpart " + part_type + " {}% {}%".format(i, i + part_size_percent))
+    for start in range(0, 100, part_size_percent):
+        end = start + part_size_percent
+        if end > 100: break
+        if end + part_size_percent > 100: end = 100
+        cmd.append("mkpart " + part_type + " {}% {}%".format(start, end))
 
     subprocess.check_call(cmd, timeout=30)
 


### PR DESCRIPTION
**Fixed kernel panic on snapshot destroy for a partition**

The kernel panic was happening in case if there are multiple snapshot
devices are for the multiple partitions of the same disk. The problem
was for the kernels 5.9+.

There is a logic for these kernels to replace `block_device_operations`
structure with the driver's tracing function instead of an original
`submit_bio`. This struct belongs to the disk, and it's shared between
partitions of the disk.

The issue was in the access to the freed memory after ours tracing
struct was freed.

Now we are not allocating a new struct when setting up a snapshot for
the 2nd+ partition of the disk. And this struct is freed just when the
last snapshot for some partition of the disk has been destroyed.

The driver has the same behavior with the `make_request` function in
the bio queue for the kernel versions before 5.9. It's replaced with the
tracking function on the first setup snapshot operation for multiple
partitions of the disk. And an original `make_request` is set back when
the last snapshot device has been destroyed respectively.
So, now this behaviour is consistent for all Linux kernel versions.

Fixes https://github.com/elastio/elastio-snap/issues/155

**Implemented new tests for snaps of partitions of the same disk**

The idea is to add a test on the loopback device with 2 or more partitions.
This test should reproduce the bug #155 like this:
1) create snapshots for both partitions of the disk (loopback device);
2) destroy 2nd snapshot device;
3) perform write to the 2nd partition;
4) wait a bit.

These steps are leading to the kernel panic without the fix.

Also added 2 other tests: simple setup test and a test with writes
to all partitions.

**Fixed tests if they are running on machine with '/' on LVM**

There is a test `test_setup_2_volumes` which uses one synthetic device
and 2nd is a root volume of the host machine. This test was failing due
to the multiple and different device names for LVM devices like
`/dev/mapper/ubuntu--vg-ubuntu--lv` and `/dev/dm-0` which are the same
device.