### PR TITLE
Fixed attempt to access beyond end of device

### DIFF
--- a/src/configure-tests/feature-tests/bio_remapped.c
+++ b/src/configure-tests/feature-tests/bio_remapped.c
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Copyright (C) 2020 Elastio Software Inc.
+ * Copyright (C) 2022 Elastio Software Inc.
  */
+
+// kernel_version > 5.12
 
 #include "includes.h"
 MODULE_LICENSE("GPL");

--- a/src/configure-tests/feature-tests/bio_remapped.c
+++ b/src/configure-tests/feature-tests/bio_remapped.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct bio bio;
+
+	bio_set_flag(&bio, BIO_REMAPPED);
+}

--- a/src/configure-tests/feature-tests/bio_throttled.c
+++ b/src/configure-tests/feature-tests/bio_throttled.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct bio bio;
+
+	bio_set_flag(&bio, BIO_THROTTLED);
+}

--- a/src/configure-tests/feature-tests/bio_throttled.c
+++ b/src/configure-tests/feature-tests/bio_throttled.c
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Copyright (C) 2020 Elastio Software Inc.
+ * Copyright (C) 2022 Elastio Software Inc.
  */
+
+// kernel_version > 4.10
 
 #include "includes.h"
 MODULE_LICENSE("GPL");

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -2866,6 +2866,14 @@ static int bio_make_read_clone(struct block_device *bdev, struct bio_set *bs, st
 	bio_sector(new_bio) = sect;
 	bio_idx(new_bio) = 0;
 
+	/*
+	 * The following flags were added
+	 * in v4.10 and in v5.12 respectively
+	 * and may affect bio processing sequence.
+	 * For this reason, we copy them from the
+	 * original bio
+	 */
+
 #if defined HAVE_BIO_REMAPPED
 	if (bio_flagged(orig_bio, BIO_REMAPPED))
 		bio_set_flag(new_bio, BIO_REMAPPED);

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -625,7 +625,6 @@ static inline int elastio_snap_call_mrf(make_request_fn *fn, struct bio *bio){
 		#define MRF_RETURN_TYPE void
 		#define MRF_RETURN(ret) return
 		#define MRF_RETURN_TYPE_VOID
-		#define BIO_REDIRECT_TO_PART0
 	#else
 		// Linux kernel version 5.9 - 5.15
 		#define MRF_RETURN_TYPE blk_qc_t
@@ -2871,14 +2870,6 @@ static int bio_make_read_clone(struct block_device *bdev, struct bio_set *bs, st
 		bio_set_flag(new_bio, BIO_REMAPPED);
 	if (bio_flagged(orig_bio, BIO_THROTTLED))
 		bio_set_flag(new_bio, BIO_THROTTLED);
-
-#ifdef BIO_REDIRECT_TO_PART0
-	/**
-	 * starting from 5.16+ we change the device to the root partition
-	 * to make sure the 'dev->sd_sect_off' math remains the same
-	 */
-	new_bio->bi_bdev = new_bio->bi_bdev->bd_disk->part0;
-#endif
 
 	//fill the bio with pages
 	for(i = 0; i < actual_pages; i++){

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -2866,10 +2866,15 @@ static int bio_make_read_clone(struct block_device *bdev, struct bio_set *bs, st
 	bio_sector(new_bio) = sect;
 	bio_idx(new_bio) = 0;
 
+#if defined HAVE_BIO_REMAPPED
 	if (bio_flagged(orig_bio, BIO_REMAPPED))
 		bio_set_flag(new_bio, BIO_REMAPPED);
+#endif
+
+#if defined HAVE_BIO_THROTTLED
 	if (bio_flagged(orig_bio, BIO_THROTTLED))
 		bio_set_flag(new_bio, BIO_THROTTLED);
+#endif
 
 	//fill the bio with pages
 	for(i = 0; i < actual_pages; i++){

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -2867,6 +2867,11 @@ static int bio_make_read_clone(struct block_device *bdev, struct bio_set *bs, st
 	bio_sector(new_bio) = sect;
 	bio_idx(new_bio) = 0;
 
+	if (bio_flagged(orig_bio, BIO_REMAPPED))
+		bio_set_flag(new_bio, BIO_REMAPPED);
+	if (bio_flagged(orig_bio, BIO_THROTTLED))
+		bio_set_flag(new_bio, BIO_THROTTLED);
+
 #ifdef BIO_REDIRECT_TO_PART0
 	/**
 	 * starting from 5.16+ we change the device to the root partition

--- a/tests/devicetestcase_multipart.py
+++ b/tests/devicetestcase_multipart.py
@@ -19,8 +19,8 @@ from random import randint
 class DeviceTestCaseMultipart(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        # For now let's hardcode 2 partitions
-        cls.part_count = 2
+        # For now let's hardcode 7 partitions
+        cls.part_count = 7
         cls.minors = []
         for i in range(cls.part_count):
             # Unexpectedly randint can generate 2 same numbers in a row.


### PR DESCRIPTION
This fix closes #150 and _properly_ approaches the integration of the v5.16 Linux kernel.

Previously, during the integration of the v5.16 kernel, we had an issue with the partition mounting (`test_modify_origin` couldn't pass successfully). This issue was caused by the wrong sector offset calculation. Then it was [incorrectly] considered to be a new, changed approach to the sector calculation in the modern kernel. Now we see that understanding wasn't correct.

During debugging of issue #150, a similar behavior's been found on v5.15 (ubuntu 22.04, arm64). It was found that the issue is not related to the 5.16. Hence, the solution made during that time was rather a workaround and didn't actually explain the nature of the problem.

After proper debugging, it was seen that some bio requests were processed OK, while the others had the same offset problem. It was suspected that the bug may be related to the bio's nature (depending on the issuing entity). This was confirmed: indeed, the problem was with the absent flags, that have been introduced after v5.11 (or somewhere around). This explains random failures: it seems that sometimes bio requests were issued with proper partition remapping, and sometimes not. These random differences made up the problem with the wrong offsets.

This was fixed by copying the relevant flags in `make_read_clone`. Additional compats for new kernels have been added as well.

Closes #150 