### PR TITLE
Driver fails to unload on Ubuntu 22.04

### DIFF
--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -1121,7 +1121,16 @@ static MRF_RETURN_TYPE snap_mrf(struct bio *bio);
 #endif
 
 static const struct block_device_operations snap_ops = {
-	.owner = THIS_MODULE,
+	/**
+	 * The 'owner' field is commented as it has proven itself
+	 * to cause problems with module refcount getting
+	 * unexpectedly incremented in rare situations.
+	 *
+	 * The issue was described here:
+	 * https://github.com/elastio/elastio-snap/issues/169
+	 */
+
+	/* .owner = THIS_MODULE, */
 	.open = snap_open,
 	.release = snap_release,
 #ifdef USE_BDOPS_SUBMIT_BIO

--- a/tests/kmod.py
+++ b/tests/kmod.py
@@ -5,8 +5,10 @@
 # Additional contributions by Elastio Software, Inc are Copyright (C) 2020 Elastio Software Inc.
 #
 
-import errno
 import os
+import sys
+import time
+import errno
 import subprocess
 
 
@@ -32,11 +34,27 @@ class Module(object):
 
     def unload(self):
         cmd = ["rmmod", self.name]
-        subprocess.check_call(
-            cmd,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            timeout=self.timeout)
+
+        if sys.version_info <= (3, 5):
+            subprocess.check_call(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=self.timeout)
+        else:
+            retries = 3
+            for retry in range(retries):
+                p = subprocess.run(
+                    cmd,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=self.timeout)
+
+                if p.returncode == 0:
+                    break
+                else:
+                    print("Couldn't unload the driver")
+                    time.sleep(1)
 
     def info(self):
         cmd = ["modinfo", self.path]


### PR DESCRIPTION
It was seen in #169 that in rare cases driver fails to unload on Ubuntu 22.04. This happens because, due to some reason unknown, the kernel increments the module refcount via the `owner` field. The issue was reproduced with CI tests only, there was no scenario found to reproduce it locally to debug deeper with additional tools.

In light of this, it was decided to comment the `owner` field, which doesn't seem to be causing additional stability issues on any distributive. Apart from that, additional retries were added to handle the module unloading process.

The fix has been deeply tested and proven itself as stable on all distros and architectures.

Closes #169 