### PR TITLE
Increased timeout in 'Show debug information' CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         if: always()
         run: vagrant ssh ${{env.INSTANCE_NAME}} -c "cat tests/dmesg.log; sudo dmesg -c; lsmod"
         working-directory: ${{env.BOX_DIR}}
-        timeout-minutes: 1
+        timeout-minutes: 2
 
       - name: Attach qcow2 disks
         run: |


### PR DESCRIPTION
It was seen that sometimes the timeout is not enough. Let's now set it to two minutes to see how it works.