### PR TITLE
test_transition_fs_sync_cow_full fails on fedora 35

### DIFF
--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -3349,10 +3349,9 @@ error:
 static inline void wait_for_bio_complete(struct snap_device *dev)
 {
 	struct bio_queue *bq = &dev->sd_cow_bios;
-	if (atomic64_read(&dev->sd_received_cnt) != atomic64_read(&dev->sd_processed_cnt))
-		wait_event_interruptible_timeout(bq->event,
-				atomic64_read(&dev->sd_submitted_cnt) == atomic64_read(&dev->sd_processed_cnt),
-				msecs_to_jiffies(500));
+	wait_event_interruptible_timeout(bq->event,
+			atomic64_read(&dev->sd_submitted_cnt) == atomic64_read(&dev->sd_processed_cnt),
+			msecs_to_jiffies(500));
 }
 
 #ifdef HAVE_BIO_ENDIO_INT
@@ -4930,7 +4929,6 @@ static int ioctl_elastio_snap_info(struct elastio_snap_info *info){
 	if(ret) goto error;
 
 	dev = snap_devices[info->minor];
-	wait_for_bio_complete(dev);
 
 	tracer_elastio_snap_info(dev, info);
 

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -3354,7 +3354,7 @@ static inline void wait_for_bio_complete(struct snap_device *dev)
 	if (!wait_event_interruptible_timeout(bq->event,
 			atomic64_read(&dev->sd_submitted_cnt) == atomic64_read(&dev->sd_processed_cnt),
 			msecs_to_jiffies(WAIT_SUBMITTED_BIOS_MSEC))) {
-		LOG_DEBUG("failed wait for all submitted BIOs to be processed after %d ms. bio submitted = %lld, bio processed = %lld",
+		LOG_WARN("failed wait for all submitted BIOs to be processed after %d ms. bio submitted = %lld, bio processed = %lld",
 				WAIT_SUBMITTED_BIOS_MSEC, atomic64_read(&dev->sd_submitted_cnt), atomic64_read(&dev->sd_processed_cnt));
 	}
 }


### PR DESCRIPTION
It was seen that at the time when ioctl (transition to incremental) takes place, we still got some unprocessed bio in snap_cow_thread(). As the solution, it is proposed to add some wait in ioctl handlers to make sure all bio requests have been processed.

Here is the log explaining the behavior previously observed. Please take a look at the counters of the received (queued) and processed bio requests:

```
[  461.946031] elastio-snap: ioctl command received: 1074020613 
[  461.946033] elastio-snap: received transition inc ioctl - 19
[  461.946034] elastio-snap:    >> WAITING STARTED (bio received=61, bio processed=48)...
[  461.946759] elastio-snap: error handling write bio in kernel thread: -27
[  461.946034] elastio-snap:    >> WAITING FINISHED (bio received=61, bio processed=61)...
[  462.460080] elastio-snap: device specified is in the fail state: -27
[  462.461223] elastio-snap: error during transition to incremental ioctl handler: -27
[  462.462313] elastio-snap: minor range = 19 - 19
```

Closes #170