### PR TITLE
Show any errors on /proc/elastio-snap-info

### DIFF
--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -1247,6 +1247,20 @@ static inline void tracer_set_cow_fail_state(struct snap_device *dev, int error)
 	smp_mb();
 }
 
+static inline int tracer_fail_state(struct snap_device *dev){
+	int err;
+
+	err = tracer_read_fail_state(dev);
+	if (err == 0) {
+		err = tracer_read_memory_fail_state(dev);
+		if (err == 0) {
+			err = tracer_read_cow_fail_state(dev);
+		}
+	}
+
+	return err;
+}
+
 /************************IOCTL COPY FROM USER FUNCTIONS************************/
 
 static int copy_string_from_user(const char __user *data, char **out_ptr){
@@ -4678,14 +4692,7 @@ static void tracer_reconfigure(struct snap_device *dev, unsigned long cache_size
 static void tracer_elastio_snap_info(const struct snap_device *dev, struct elastio_snap_info *info){
 	info->minor = dev->sd_minor;
 	info->state = dev->sd_state;
-	info->error = tracer_read_fail_state(dev);
-	if (info->error == 0) {
-		info->error = tracer_read_memory_fail_state(dev);
-		if (info->error == 0)
-		{
-			info->error = tracer_read_cow_fail_state(dev);
-		}
-	}
+	info->error = tracer_fail_state(dev);
 	info->cache_size = (dev->sd_cache_size)? dev->sd_cache_size : elastio_snap_cow_max_memory_default;
 	strlcpy(info->cow, dev->sd_cow_path, PATH_MAX);
 	strlcpy(info->bdev, dev->sd_bdev_path, PATH_MAX);
@@ -4852,10 +4859,7 @@ static int ioctl_transition_inc(unsigned int minor){
 	wait_for_bio_complete(dev);
 
 	//check that the device is not in the fail state
-	ret = tracer_read_fail_state(dev);
-	if (ret == 0) {
-		ret = tracer_read_cow_fail_state(dev);
-	}
+	ret = tracer_fail_state(dev);
 	if (ret) {
 		LOG_ERROR(ret, "device specified is in the fail state");
 		goto error;
@@ -5962,7 +5966,7 @@ static int elastio_snap_proc_show(struct seq_file *m, void *v){
 			}
 		}
 
-		error = tracer_read_fail_state(dev);
+		error = tracer_fail_state(dev);
 		if(error) seq_printf(m, "\t\t\t\"error\": %d,\n", error);
 
 		seq_printf(m, "\t\t\t\"state\": %lu\n", dev->sd_state);

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -1247,7 +1247,7 @@ static inline void tracer_set_cow_fail_state(struct snap_device *dev, int error)
 	smp_mb();
 }
 
-static inline int tracer_fail_state(struct snap_device *dev){
+static inline int tracer_fail_state(const struct snap_device *dev){
 	int err;
 
 	err = tracer_read_fail_state(dev);


### PR DESCRIPTION
When cow file out of space, then snapshot switched to failed state. But this state not visible in elastio-snap-info. 
Steps to reproduce:
```
root# mkdir /tmp/fs
root# truncate -s 2G test.img
root# losetup /dev/loop16  test.img
root# mkfs.ext4 /dev/loop16
root# mount  /dev/loop16 /tmp/fs
root# elioctl setup-snapshot -c 10 -f 1 /dev/loop16 /tmp/fs/.eliosnap 0
root# dd if=/dev/urandom of=/tmp/fs/big_file count=100 bs=1M
root# dmesg | tail
[694212.900953] elastio-snap: cow file '/tmp/fs/.eliosnap' max size exceeded (4198400/1048576): -27
[694212.900960] elastio-snap: error writing cow data: -27
[694212.900963] elastio-snap: error writing cow data and mapping: -27
[694212.900965] elastio-snap: error handling write bio: -27
[694212.900967] elastio-snap: error handling write bio in kernel thread: -27
root#  cat /proc/elastio-snap-info
{
        "version": "0.11.0",
        "devices": [
                {
                        "minor": 0,
                        "cow_file": "/.eliosnap",
                        "block_device": "/dev/loop16",
                        "max_cache": 10,
                        "fallocate": 1048576,
                        "seq_id": 1,
                        "uuid": "3d9527c07b854ff1b1f1a69b777a49a8",
                        "version": 1,
                        "nr_changed_blocks": 1,
                        "state": 3
                }
        ]
}

```
After this patch was added field "error":
```
root#  cat /proc/elastio-snap-info
{
        "version": "0.11.0",
        "devices": [
                {
                        "minor": 0,
                        "cow_file": "/.eliosnap",
                        "block_device": "/dev/loop16",
                        "max_cache": 10,
                        "fallocate": 1048576,
                        "seq_id": 1,
                        "uuid": "3d9527c07b854ff1b1f1a69b777a49a8",
                        "version": 1,
                        "nr_changed_blocks": 1,
                        "error": -27,
                        "state": 3
                }
        ]
}
```
