### PR TITLE
Add builds for CentOS Stream 9 and allow CI runs on PRs from external forks

### DIFF
--- a/.github/buildbox/Vagrantfile
+++ b/.github/buildbox/Vagrantfile
@@ -32,13 +32,15 @@ ENV_VARS_SCRIPT
 DISTRO = {}
 DISTRO['amd64'] = [ "debian8", "debian9", "debian10", "debian11",
                     "amazon2",
-                    "centos6", "centos7", "centos8",
+                    "centos7", "centos8", "centos9",
+                    "alma8", "alma9",
                     "fedora31", "fedora32", "fedora34", "fedora35", "fedora36",
                     "ubuntu2004", "ubuntu2204" ]
 
 DISTRO['arm64'] = [ "debian10", "debian11",
                     "amazon2",
-                    "centos8",
+                    "centos8", "centos9",
+                    "alma8", "alma9",
                     "fedora35", "fedora36",
                     "ubuntu2204" ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         distro: [
           amazon2,
-          centos7, centos8,
+          centos7, centos8, centos9,
           debian8, debian9, debian10, debian11,
           fedora31, fedora32, fedora34, fedora35, fedora36,
           ubuntu2004, ubuntu2204
@@ -34,6 +34,8 @@ jobs:
           - distro: amazon2
             arch: arm64
           - distro: centos8
+            arch: arm64
+          - distro: centos9
             arch: arm64
           - distro: debian10
             arch: arm64
@@ -48,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set ENV
         if: always()
@@ -326,7 +328,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Make manifest
         run: echo $GITHUB_RUN_NUMBER > latest && cat latest | grep -E '^[0-9]+$'
@@ -351,7 +353,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Dispatch packaging repo
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@
 name: ci
 on:
   - push
+  - pull_request_target
 
 env:
   AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -299,6 +300,7 @@ jobs:
           done
 
       - name: Upload artifacts
+        if: ${{ github.event_name == 'push' }}
         run: |
           excl_ptrn="*GPG-KEY"
           # We have to avoid a race condition when package like elastio-snap-dkms_X.XX.XX-1debian11_all.deb is uploaded from
@@ -321,6 +323,7 @@ jobs:
         run: .github/scripts/destroy_box.sh
 
   manifest:
+    if: ${{ github.event_name == 'push' }}
     name: Artifacts manifest
     needs: build-packages
     runs-on:
@@ -346,6 +349,7 @@ jobs:
             ${tag}
 
   dispatch-packaging-repo:
+    if: ${{ github.event_name == 'push' }}
     name: Trigger repo upload
     needs: manifest
     runs-on:


### PR DESCRIPTION
- Added builds for CentOS Stream 9
- Updated checkout action from v2 to v3
- Allowed to run CI checks on event `pull_request_target`.
  These checks will perform tests but will not upload artifacts.
  This change allows to approve CI runs on PRs from external forks.
  See doc for more info https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks