### PR TITLE
Fix PR CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 ---
 name: ci
 on:
-  - push
-  - pull_request_target
+  push:
+    branches:
+      - master
+      - 'release'
+      - 'debug/**'
+  pull_request: ~
 
 env:
   AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 'release'
+      - 'release**'
       - 'debug/**'
   pull_request: ~
 


### PR DESCRIPTION
- Changed `pull_request_target` to `pull_request`. The 1st one is too open
  and don't require approval for CI runs from the forks.

- Filtered just some branches for CI runs on `push` to avoid too many CI
  usage while pushing to a branch and creating a PR.
  There are 3 allowed branch names: `master`, `release**`, and a special
  one for "debugging on CI" `debug/**`.