### PR TITLE
Split large bio requests in advance

### DIFF
--- a/src/configure-tests/feature-tests/bio_split_4.c
+++ b/src/configure-tests/feature-tests/bio_split_4.c
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Copyright (C) 2015 Datto Inc.
- * Additional contributions by Elastio Software, Inc are Copyright (C) 2020 Elastio Software Inc.
+ * Copyright (C) 2022 Elastio Software Inc.
  */
 
 // kernel version < 3.14

--- a/src/configure-tests/feature-tests/bio_split_4.c
+++ b/src/configure-tests/feature-tests/bio_split_4.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2015 Datto Inc.
+ * Additional contributions by Elastio Software, Inc are Copyright (C) 2020 Elastio Software Inc.
+ */
+
+// kernel version < 3.14
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct bio _bio = { 0 };
+	struct bio *split = NULL;
+	split = bio_split(&_bio, 128, GFP_NOIO, NULL);
+}

--- a/src/configure-tests/feature-tests/bio_split_4.c
+++ b/src/configure-tests/feature-tests/bio_split_4.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2022 Elastio Software Inc.
  */
 
-// kernel version < 3.14
+// kernel version > 3.14
 
 #include "includes.h"
 MODULE_LICENSE("GPL");

--- a/src/configure-tests/feature-tests/generic_make_request.c
+++ b/src/configure-tests/feature-tests/generic_make_request.c
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Copyright (C) 2015 Datto Inc.
- * Additional contributions by Elastio Software, Inc are Copyright (C) 2020 Elastio Software Inc.
+ * Copyright (C) 2022 Elastio Software Inc.
  */
 
 // kernel_version < 5.9

--- a/src/configure-tests/feature-tests/generic_make_request.c
+++ b/src/configure-tests/feature-tests/generic_make_request.c
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2015 Datto Inc.
+ * Additional contributions by Elastio Software, Inc are Copyright (C) 2020 Elastio Software Inc.
+ */
+
+// kernel_version < 5.9
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct bio _bio = { 0 };
+	generic_make_request(&_bio);
+}


### PR DESCRIPTION
This PR closes the memory overflow issue on some cloud-based instances.

The root cause of memory overflow in #96 on the AWS EC2 instance was that we held the initial bio request [the one we want to backup] and all its "clones" for a significant amount of time. Briefly [more on that below!], this was possible due to several reasons:

 - A big size of initial bio requests to backup (created by `cp` or `dd` - could be 10 MB or more)
 - A small value of `/sys/block/<blockdevice>/queue/max_sectors_kb` that limits the size of a single bio request to be processed
 - While processing the initial bio, this creates a bottleneck and forces the OS to additionally split bio requests which were cloned from the initial one
 - Even more, the default scheduler [mq-deadline] reorders these cloned bio requests causing a significant lifetime of the memory allocated

**Why this wasn't the case without our driver?**

Normally, after the operating system splits the original bio, their order isn't important anymore and the scheduler can do with them whatever it wants. The order of write operations affects literally nothing in that case, and the throughput of these I/O was limited only by the max size of a bio request defined by the OS. Apart from that, no additional memory allocation was required.

**What changed with elastio-snap?**

 - First, we split the initial bio request into smaller (but still quite big for the system) fragments 256 segments each
 - While this is done, we create a full copy of each bio, hence occupying x2 memory overall
 - Driver-dependent thing: when smaller fragments from the previous iteration are sent to a system, the original bio isn't released until all (!) the child operations are completed. But [unluckily] for the OS our "cloned" bios are still too big (which depends on `max_sectors_kb`), so it splits these fragments even more, causing a significant delay
 - As the last nail in the coffin, some of the I/O schedulers (`mq-deadline` in my case) can reorder these bio requests (increasing the delay dramatically)
 - All these factors summed up cause the driver to hold all fragments for way too long, which, eventually, causes the memory overflow

**What is the solution proposed?**

The first goal is to decrease the number of cloned fragments to wait for before the initial bio is released. To do this, we keep the principle: we see the big bio - we split it in advance, truncating it to `max_sectors_kb` size. Hence we make sure it won't be split by the OS. This is what this PR is about.

Second, in elastio, we disable the scheduler that can reorder lots of our "clones" as it drastically affects the lifetime of the initial bio request. This step isn't mandatory, but it helps to create a snapshot environment that doesn't consume additional memory at all (well, technically it certainly does, but mainly, you won't see any changes in memory consumption). Luckily for us, this is per block device feature, so other devices of the block subsystem won't be affected. And, of course, you can change the scheduler back in runtime, just as simple as that:

`echo none > /sys/block/xvda/queue/scheduler`

**Summary**

 - Implemented compat files to determine an old version of `bio_split()` and `generic_make_request()` functions
 - Implemented the split-in-advance functionality

Closes #96 