### PR TITLE
Implement functionality to switch on/of EIO propagation on snap read

### DIFF
--- a/app/elioctl.c
+++ b/app/elioctl.c
@@ -24,7 +24,7 @@ static void print_help(int status){
 	printf("\telioctl reload-incremental [-c <cache size>] <block device> <cow file> <minor>\n");
 	printf("\telioctl destroy <minor>\n");
 	printf("\telioctl transition-to-incremental <minor>\n");
-	printf("\telioctl transition-to-snapshot [-f fallocate] [-i (ignore snap errors)] <cow file> <minor>\n");
+	printf("\telioctl transition-to-snapshot [-f fallocate] <cow file> <minor>\n");
 	printf("\telioctl reconfigure [-c <cache size>] <minor>\n");
 	printf("\telioctl info <minor>\n");
 	printf("\telioctl get-free-minor\n");
@@ -266,18 +266,14 @@ static int handle_transition_snap(int argc, char **argv){
 	int ret, c;
 	unsigned int minor;
 	unsigned long fallocated_space = 0;
-	bool ignore_snap_errors = false;
 	char *cow;
 
 	//get fallocated space and ignore snap errors params, if given
-	while((c = getopt(argc, argv, "f:i:")) != -1){
+	while((c = getopt(argc, argv, "f:")) != -1){
 		switch(c){
 		case 'f':
 			ret = parse_ul(optarg, &fallocated_space);
 			if(ret) goto error;
-			break;
-		case 'i':
-			ignore_snap_errors = true;
 			break;
 		default:
 			errno = EINVAL;
@@ -295,7 +291,7 @@ static int handle_transition_snap(int argc, char **argv){
 	ret = parse_ui(argv[optind + 1], &minor);
 	if(ret) goto error;
 
-	return elastio_snap_transition_snapshot(minor, cow, fallocated_space, ignore_snap_errors);
+	return elastio_snap_transition_snapshot(minor, cow, fallocated_space);
 
 error:
 	perror("error interpreting transition to snapshot parameters");

--- a/app/elioctl.c
+++ b/app/elioctl.c
@@ -31,9 +31,10 @@ static void print_help(int status){
 	printf("\telioctl help\n\n");
 	printf("<cow file> should be specified as an absolute path.\n");
 	printf("cache size should be provided in bytes, and fallocate should be provided in megabytes.\n");
-	printf("note: if the -c or -f options are not specified for any given call, module defaults are used.\n");
-	printf("-i allows to not propagate IO errors on snapshot read operations when the snapshot is in the failed state.\n");
-	printf("   it should be specified avoid SIGBUS on an error while reading the snapshot device as a memory-mapped file.\n");
+	printf("note:\n");
+	printf("  * if the -c or -f options are not specified for any given call, module defaults are used.\n");
+	printf("  * -i allows to not propagate IO errors on snapshot read operations when the snapshot is in the failed state.\n");
+	printf("    it should be specified to avoid SIGBUS on an error while reading the snapshot device as a memory-mapped file.\n");
 	exit(status);
 }
 

--- a/app/elioctl.c
+++ b/app/elioctl.c
@@ -382,7 +382,8 @@ static int handle_info(int argc, char **argv){
 
 		if(info.error) printf("\t\"error\": %d,\n", info.error);
 
-		printf("\t\"state\": %lu\n", info.state);
+		printf("\t\"state\": %lu,\n", info.state);
+		printf("\t\"ignore_snap_errors\": %i\n", info.ignore_snap_errors);
 		printf("}\n");
 	}
 

--- a/app/elioctl.c
+++ b/app/elioctl.c
@@ -276,8 +276,8 @@ static int handle_transition_snap(int argc, char **argv){
 	unsigned long fallocated_space = 0;
 	char *cow;
 
-	//get fallocated space and ignore snap errors params, if given
-	while((c = getopt(argc, argv, "f")) != -1){
+	//get fallocated space param, if given
+	while((c = getopt(argc, argv, "f:")) != -1){
 		switch(c){
 		case 'f':
 			ret = parse_ul(optarg, &fallocated_space);

--- a/app/elioctl.c
+++ b/app/elioctl.c
@@ -107,7 +107,7 @@ static int handle_setup_snap(int argc, char **argv){
 	char *bdev, *cow;
 
 	//get cache size, fallocated space and ignore errors on snap dev params, if given
-	while((c = getopt(argc, argv, "c:f:i:")) != -1){
+	while((c = getopt(argc, argv, "c:f:i")) != -1){
 		switch(c){
 		case 'c':
 			ret = parse_ul(optarg, &cache_size);
@@ -127,6 +127,7 @@ static int handle_setup_snap(int argc, char **argv){
 	}
 
 	if(argc - optind != 3){
+
 		errno = EINVAL;
 		goto error;
 	}

--- a/app/elioctl.c
+++ b/app/elioctl.c
@@ -20,8 +20,8 @@
 static void print_help(int status){
 	printf("Usage:\n");
 	printf("\telioctl setup-snapshot [-c <cache size>] [-f fallocate] [-i (ignore snap errors)] <block device> <cow file> <minor>\n");
-	printf("\telioctl reload-snapshot [-c <cache size>] <block device> <cow file> <minor>\n");
-	printf("\telioctl reload-incremental [-c <cache size>] <block device> <cow file> <minor>\n");
+	printf("\telioctl reload-snapshot [-c <cache size>] [-i (ignore snap errors)] <block device> <cow file> <minor>\n");
+	printf("\telioctl reload-incremental [-c <cache size>] [-i (ignore snap errors)] <block device> <cow file> <minor>\n");
 	printf("\telioctl destroy <minor>\n");
 	printf("\telioctl transition-to-incremental <minor>\n");
 	printf("\telioctl transition-to-snapshot [-f fallocate] <cow file> <minor>\n");
@@ -151,13 +151,17 @@ static int handle_reload_snap(int argc, char **argv){
 	unsigned int minor;
 	unsigned long cache_size = 0;
 	char *bdev, *cow;
+	bool ignore_snap_errors = false;
 
-	//get cache size, if given
-	while((c = getopt(argc, argv, "c:")) != -1){
+	//get cache size, ignore_errors if given
+	while((c = getopt(argc, argv, "c:i")) != -1){
 		switch(c){
 		case 'c':
 			ret = parse_ul(optarg, &cache_size);
 			if(ret) goto error;
+			break;
+		case 'i':
+			ignore_snap_errors = true;
 			break;
 		default:
 			errno = EINVAL;
@@ -176,7 +180,7 @@ static int handle_reload_snap(int argc, char **argv){
 	ret = parse_ui(argv[optind + 2], &minor);
 	if(ret) goto error;
 
-	return elastio_snap_reload_snapshot(minor, bdev, cow, cache_size);
+	return elastio_snap_reload_snapshot(minor, bdev, cow, cache_size, ignore_snap_errors);
 
 error:
 	perror("error interpreting reload snapshot parameters");
@@ -189,13 +193,17 @@ static int handle_reload_inc(int argc, char **argv){
 	unsigned int minor;
 	unsigned long cache_size = 0;
 	char *bdev, *cow;
+	bool ignore_snap_errors = false;
 
-	//get cache size and fallocated space params, if given
-	while((c = getopt(argc, argv, "c:")) != -1){
+	//get cache size, ignore_errors and fallocated space params, if given
+	while((c = getopt(argc, argv, "c:i")) != -1){
 		switch(c){
 		case 'c':
 			ret = parse_ul(optarg, &cache_size);
 			if(ret) goto error;
+			break;
+		case 'i':
+			ignore_snap_errors = true;
 			break;
 		default:
 			errno = EINVAL;
@@ -214,7 +222,7 @@ static int handle_reload_inc(int argc, char **argv){
 	ret = parse_ui(argv[optind + 2], &minor);
 	if(ret) goto error;
 
-	return elastio_snap_reload_incremental(minor, bdev, cow, cache_size);
+	return elastio_snap_reload_incremental(minor, bdev, cow, cache_size, ignore_snap_errors);
 
 error:
 	perror("error interpreting reload incremental parameters");
@@ -269,7 +277,7 @@ static int handle_transition_snap(int argc, char **argv){
 	char *cow;
 
 	//get fallocated space and ignore snap errors params, if given
-	while((c = getopt(argc, argv, "f:")) != -1){
+	while((c = getopt(argc, argv, "f")) != -1){
 		switch(c){
 		case 'f':
 			ret = parse_ul(optarg, &fallocated_space);

--- a/app/elioctl.c
+++ b/app/elioctl.c
@@ -128,7 +128,6 @@ static int handle_setup_snap(int argc, char **argv){
 	}
 
 	if(argc - optind != 3){
-
 		errno = EINVAL;
 		goto error;
 	}

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -106,7 +106,7 @@
 
 
 Name:            elastio-snap
-Version:         0.11.1
+Version:         0.12.0
 Release:         1%{?dist}
 Summary:         Kernel module and utilities for enabling low-level live backups
 Vendor:          Elastio Software, Inc.
@@ -599,6 +599,10 @@ rm -rf %{buildroot}
 
 
 %changelog
+
+* Wed Dec 21 2022 Eugene Kovalenko <ikovalenko@elastio.com> - 0.12.0
+- Simplified error handling, got rid of sd_memory_fail_code and sd_cow_fail_state snapshot struct members
+- Added arg to some IOCTLs and lib funcs to switch off IO errors on read of a snap device in the failed state (helps to avoid SIGBUS on mem-mapped snap device)
 
 * Thu Dec 15 2022 Stanislav Barantsev <sbarantsev@elastio.com> - 0.11.1
 - Fixed memory overflow on slow storages by splitting large bio requests in advance, if necessary

--- a/doc/elioctl.8
+++ b/doc/elioctl.8
@@ -27,25 +27,28 @@ This manual page describes \fBelioctl\fR briefly\. More detail is available in t
 
 \-f fallocate
      Specify the maximum size of the COW file on disk\.
+
+\-i
+     Specify to ignore IO errors while reading a snapshot device in case of any error\. This is useful to avoid SIGBUS when using the snapshot devise as a memory-mapped file\.
 .
 .fi
 .
 .SH "SUB\-COMMANDS"
 .
 .SS "setup\-snapshot"
-\fBelioctl setup\-snapshot [\-c <cache size>] [\-f <fallocate>] <block device> <cow file path> <minor>\fR
+\fBelioctl setup\-snapshot [\-c <cache size>] [\-f <fallocate>] [\-i] <block device> <cow file path> <minor>\fR
 .
 .P
 Sets up a snapshot of \fB<block device>\fR, saving all COW data to \fB<cow file path>\fR\. The snapshot device will be \fB/dev/elastio\-snap<minor>\fR\. The minor number will be used as a reference number for all other \fBelioctl\fR commands\. \fB<cow file path>\fR must be a path on the \fB<block device>\fR\.
 .
 .SS "reload\-snapshot"
-\fBelioctl reload\-snapshot [\-c <cache size>] <block device> <cow file> <minor>\fR
+\fBelioctl reload\-snapshot [\-c <cache size>] [\-i] <block device> <cow file> <minor>\fR
 .
 .P
 Reloads a snapshot\. This command is meant to be run before the block device is mounted, after a reboot or after the driver is unloaded\. It notifies the kernel driver to expect the block device specified to come back online\. This command requires that the snapshot was cleanly unmounted in snapshot mode beforehand\. If this is not the case, the snapshot will be put into the failure state once it attempts to come online\. The minor number will be used as a reference number for all other \fBelioctl\fR commands\.
 .
 .SS "reload\-incremental"
-\fBelioctl reload\-incremental [\-c <cache size>] <block device> <cow file> <minor>\fR
+\fBelioctl reload\-incremental [\-c <cache size>] [\-i] <block device> <cow file> <minor>\fR
 .
 .P
 Reloads a block device that was in incremental mode\. See \fBreload\-snapshot\fR for restrictions\.

--- a/doc/elioctl.8.html
+++ b/doc/elioctl.8.html
@@ -94,25 +94,28 @@
 
 -f fallocate
      Specify the maximum size of the COW file on disk.
+
+-i
+     Specify to ignore IO errors while reading a snapshot device in case of any error. This is useful to avoid SIGBUS when using the snapshot devise as a memory-mapped file.
 </code></pre>
 
 <h2 id="SUB-COMMANDS">SUB-COMMANDS</h2>
 
 <h3 id="setup-snapshot">setup-snapshot</h3>
 
-<p><code>elioctl setup-snapshot [-c &lt;cache size>] [-f &lt;fallocate>] &lt;block device> &lt;cow file path> &lt;minor></code></p>
+<p><code>elioctl setup-snapshot [-c &lt;cache size>] [-f &lt;fallocate>] [-i] &lt;block device> &lt;cow file path> &lt;minor></code></p>
 
 <p>Sets up a snapshot of <code>&lt;block device></code>, saving all COW data to <code>&lt;cow file path></code>. The snapshot device will be <code>/dev/elastio-snap&lt;minor></code>. The minor number will be used as a reference number for all other <code>elioctl</code> commands. <code>&lt;cow file path></code> must be a path on the <code>&lt;block device></code>.</p>
 
 <h3 id="reload-snapshot">reload-snapshot</h3>
 
-<p><code>elioctl reload-snapshot [-c &lt;cache size>] &lt;block device> &lt;cow file> &lt;minor></code></p>
+<p><code>elioctl reload-snapshot [-c &lt;cache size>] [-i] &lt;block device> &lt;cow file> &lt;minor></code></p>
 
 <p>Reloads a snapshot. This command is meant to be run before the block device is mounted, after a reboot or after the driver is unloaded. It notifies the kernel driver to expect the block device specified to come back online. This command requires that the snapshot was cleanly unmounted in snapshot mode beforehand. If this is not the case, the snapshot will be put into the failure state once it attempts to come online. The minor number will be used as a reference number for all other <code>elioctl</code> commands.</p>
 
 <h3 id="reload-incremental">reload-incremental</h3>
 
-<p><code>elioctl reload-incremental [-c &lt;cache size>] &lt;block device> &lt;cow file> &lt;minor></code></p>
+<p><code>elioctl reload-incremental [-c &lt;cache size>] [-i] &lt;block device> &lt;cow file> &lt;minor></code></p>
 
 <p>Reloads a block device that was in incremental mode. See <code>reload-snapshot</code> for restrictions.</p>
 

--- a/doc/elioctl.8.md
+++ b/doc/elioctl.8.md
@@ -19,23 +19,26 @@ This manual page describes `elioctl` briefly. More detail is available in the Gi
     -f fallocate
          Specify the maximum size of the COW file on disk.
 
+    -i
+         Specify to ignore IO errors while reading a snapshot device in case of any error. This is useful to avoid SIGBUS when using the snapshot devise as a memory-mapped file.
+
 ## SUB-COMMANDS
 
 ### setup-snapshot
 
-`elioctl setup-snapshot [-c <cache size>] [-f <fallocate>] <block device> <cow file path> <minor>`
+`elioctl setup-snapshot [-c <cache size>] [-f <fallocate>] [-i] <block device> <cow file path> <minor>`
 
 Sets up a snapshot of `<block device>`, saving all COW data to `<cow file path>`. The snapshot device will be `/dev/elastio-snap<minor>`. The minor number will be used as a reference number for all other `elioctl` commands. `<cow file path>` must be a path on the `<block device>`.
 
 ### reload-snapshot
 
-`elioctl reload-snapshot [-c <cache size>] <block device> <cow file> <minor>`
+`elioctl reload-snapshot [-c <cache size>] [-i] <block device> <cow file> <minor>`
 
 Reloads a snapshot. This command is meant to be run before the block device is mounted, after a reboot or after the driver is unloaded. It notifies the kernel driver to expect the block device specified to come back online. This command requires that the snapshot was cleanly unmounted in snapshot mode beforehand. If this is not the case, the snapshot will be put into the failure state once it attempts to come online. The minor number will be used as a reference number for all other `elioctl` commands.
 
 ### reload-incremental
 
-`elioctl reload-incremental [-c <cache size>] <block device> <cow file> <minor>`
+`elioctl reload-incremental [-c <cache size>] [-i] <block device> <cow file> <minor>`
 
 Reloads a block device that was in incremental mode. See `reload-snapshot` for restrictions.
 

--- a/lib/libelastio-snap.c
+++ b/lib/libelastio-snap.c
@@ -31,7 +31,7 @@ int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsig
 	return ret;
 }
 
-int elastio_snap_reload_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long cache_size){
+int elastio_snap_reload_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long cache_size, bool ignore_snap_errors){
 	int fd, ret;
 	struct reload_params rp;
 
@@ -42,6 +42,7 @@ int elastio_snap_reload_snapshot(unsigned int minor, char *bdev, char *cow, unsi
 	rp.bdev = bdev;
 	rp.cow = cow;
 	rp.cache_size = cache_size;
+	rp.ignore_snap_errors = ignore_snap_errors;
 
 	ret = ioctl(fd, IOCTL_RELOAD_SNAP, &rp);
 
@@ -49,7 +50,7 @@ int elastio_snap_reload_snapshot(unsigned int minor, char *bdev, char *cow, unsi
 	return ret;
 }
 
-int elastio_snap_reload_incremental(unsigned int minor, char *bdev, char *cow, unsigned long cache_size){
+int elastio_snap_reload_incremental(unsigned int minor, char *bdev, char *cow, unsigned long cache_size, bool ignore_snap_errors){
 	int fd, ret;
 	struct reload_params rp;
 
@@ -60,6 +61,7 @@ int elastio_snap_reload_incremental(unsigned int minor, char *bdev, char *cow, u
 	rp.bdev = bdev;
 	rp.cow = cow;
 	rp.cache_size = cache_size;
+	rp.ignore_snap_errors = ignore_snap_errors;
 
 	ret = ioctl(fd, IOCTL_RELOAD_INC, &rp);
 

--- a/lib/libelastio-snap.c
+++ b/lib/libelastio-snap.c
@@ -91,14 +91,13 @@ int elastio_snap_transition_incremental(unsigned int minor){
 	return ret;
 }
 
-int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space, bool ignore_snap_errors){
+int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space){
 	int fd, ret;
 	struct transition_snap_params tp;
 
 	tp.minor = minor;
 	tp.cow = cow;
 	tp.fallocated_space = fallocated_space;
-	tp.ignore_snap_errors = ignore_snap_errors;
 
 	fd = open("/dev/elastio-snap-ctl", O_RDONLY);
 	if(fd < 0) return -1;

--- a/lib/libelastio-snap.c
+++ b/lib/libelastio-snap.c
@@ -11,7 +11,7 @@
 #include <sys/ioctl.h>
 #include "libelastio-snap.h"
 
-int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long fallocated_space, unsigned long cache_size, int allow_mem_mapping){
+int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long fallocated_space, unsigned long cache_size, bool ignore_snap_errors){
 	int fd, ret;
 	struct setup_params sp;
 
@@ -23,7 +23,7 @@ int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsig
 	sp.cow = cow;
 	sp.fallocated_space = fallocated_space;
 	sp.cache_size = cache_size;
-	sp.allow_mem_mapping = allow_mem_mapping;
+	sp.ignore_snap_errors = ignore_snap_errors;
 
 	ret = ioctl(fd, IOCTL_SETUP_SNAP, &sp);
 
@@ -91,14 +91,14 @@ int elastio_snap_transition_incremental(unsigned int minor){
 	return ret;
 }
 
-int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space, int allow_mem_mapping){
+int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space, bool ignore_snap_errors){
 	int fd, ret;
 	struct transition_snap_params tp;
 
 	tp.minor = minor;
 	tp.cow = cow;
 	tp.fallocated_space = fallocated_space;
-	tp.allow_mem_mapping = allow_mem_mapping;
+	tp.ignore_snap_errors = ignore_snap_errors;
 
 	fd = open("/dev/elastio-snap-ctl", O_RDONLY);
 	if(fd < 0) return -1;

--- a/lib/libelastio-snap.c
+++ b/lib/libelastio-snap.c
@@ -11,7 +11,7 @@
 #include <sys/ioctl.h>
 #include "libelastio-snap.h"
 
-int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long fallocated_space, unsigned long cache_size){
+int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long fallocated_space, unsigned long cache_size, int allow_mem_mapping){
 	int fd, ret;
 	struct setup_params sp;
 
@@ -23,6 +23,7 @@ int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsig
 	sp.cow = cow;
 	sp.fallocated_space = fallocated_space;
 	sp.cache_size = cache_size;
+	sp.allow_mem_mapping = allow_mem_mapping;
 
 	ret = ioctl(fd, IOCTL_SETUP_SNAP, &sp);
 
@@ -90,13 +91,14 @@ int elastio_snap_transition_incremental(unsigned int minor){
 	return ret;
 }
 
-int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space){
+int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space, int allow_mem_mapping){
 	int fd, ret;
 	struct transition_snap_params tp;
 
 	tp.minor = minor;
 	tp.cow = cow;
 	tp.fallocated_space = fallocated_space;
+	tp.allow_mem_mapping = allow_mem_mapping;
 
 	fd = open("/dev/elastio-snap-ctl", O_RDONLY);
 	if(fd < 0) return -1;

--- a/lib/libelastio-snap.h
+++ b/lib/libelastio-snap.h
@@ -9,12 +9,13 @@
 #define LIBELASTIO_SNAP_H_
 
 #include "elastio-snap.h"
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long fallocated_space, unsigned long cache_size, int allow_mem_mapping);
+int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long fallocated_space, unsigned long cache_size, bool ignore_snap_errors);
 
 int elastio_snap_reload_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long cache_size);
 
@@ -24,7 +25,7 @@ int elastio_snap_destroy(unsigned int minor);
 
 int elastio_snap_transition_incremental(unsigned int minor);
 
-int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space, int allow_mem_mapping);
+int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space, bool ignore_snap_errors);
 
 int elastio_snap_reconfigure(unsigned int minor, unsigned long cache_size);
 

--- a/lib/libelastio-snap.h
+++ b/lib/libelastio-snap.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long fallocated_space, unsigned long cache_size);
+int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long fallocated_space, unsigned long cache_size, int allow_mem_mapping);
 
 int elastio_snap_reload_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long cache_size);
 
@@ -24,7 +24,7 @@ int elastio_snap_destroy(unsigned int minor);
 
 int elastio_snap_transition_incremental(unsigned int minor);
 
-int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space);
+int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space, int allow_mem_mapping);
 
 int elastio_snap_reconfigure(unsigned int minor, unsigned long cache_size);
 

--- a/lib/libelastio-snap.h
+++ b/lib/libelastio-snap.h
@@ -25,7 +25,7 @@ int elastio_snap_destroy(unsigned int minor);
 
 int elastio_snap_transition_incremental(unsigned int minor);
 
-int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space, bool ignore_snap_errors);
+int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space);
 
 int elastio_snap_reconfigure(unsigned int minor, unsigned long cache_size);
 

--- a/lib/libelastio-snap.h
+++ b/lib/libelastio-snap.h
@@ -17,9 +17,9 @@ extern "C" {
 
 int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long fallocated_space, unsigned long cache_size, bool ignore_snap_errors);
 
-int elastio_snap_reload_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long cache_size);
+int elastio_snap_reload_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long cache_size, bool ignore_snap_errors);
 
-int elastio_snap_reload_incremental(unsigned int minor, char *bdev, char *cow, unsigned long cache_size);
+int elastio_snap_reload_incremental(unsigned int minor, char *bdev, char *cow, unsigned long cache_size, bool ignore_snap_errors);
 
 int elastio_snap_destroy(unsigned int minor);
 

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -4747,6 +4747,7 @@ static void tracer_elastio_snap_info(const struct snap_device *dev, struct elast
 		info->seqid = 0;
 		memset(info->uuid, 0, COW_UUID_SIZE);
 	}
+	info->ignore_snap_errors = dev->sd_ignore_snap_errors;
 }
 
 /************************IOCTL HANDLER FUNCTIONS************************/

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -4812,8 +4812,7 @@ static int __ioctl_setup(unsigned int minor, const char *bdev_path, const char *
 	int ret, is_mounted;
 	struct snap_device *dev = NULL;
 
-	// TODO: update message for setup snap and transition to snap with the mem map value
-	LOG_DEBUG("received %s %s ioctl - %u : %s : %s", (is_reload)? "reload" : "setup", (is_snap)? "snap" : "inc", minor, bdev_path, cow_path);
+	LOG_DEBUG("received %s %s ioctl - %u : %s : %s: %s", (is_reload)? "reload" : "setup", (is_snap)? "snap" : "inc", minor, bdev_path, cow_path, (ignore_snap_errors)? "ignore_errors" : "no_ignore_errors");
 
 	//verify that the minor number is valid
 	ret = verify_minor_available(minor);

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -1388,7 +1388,7 @@ error:
 	return ret;
 }
 
-static int get_transition_snap_params(const struct transition_snap_params __user *in, unsigned int *minor, char **cow_path, unsigned long *fallocated_space, bool *ignore_snap_errors){
+static int get_transition_snap_params(const struct transition_snap_params __user *in, unsigned int *minor, char **cow_path, unsigned long *fallocated_space){
 	int ret;
 	struct transition_snap_params params;
 
@@ -1411,7 +1411,6 @@ static int get_transition_snap_params(const struct transition_snap_params __user
 
 	*minor = params.minor;
 	*fallocated_space = params.fallocated_space;
-	*ignore_snap_errors = params.ignore_snap_errors;
 	return 0;
 
 error:
@@ -4005,6 +4004,7 @@ static void __tracer_copy_base_dev(const struct snap_device *src, struct snap_de
 	dest->sd_sect_off = src->sd_sect_off;
 	dest->sd_base_dev = src->sd_base_dev;
 	dest->sd_bdev_path = src->sd_bdev_path;
+	dest->sd_ignore_snap_errors = src->sd_ignore_snap_errors;
 }
 
 static int __tracer_destroy_cow(struct snap_device *dev, int close_method){
@@ -4922,7 +4922,7 @@ error:
 	return ret;
 }
 
-static int ioctl_transition_snap(unsigned int minor, const char *cow_path, unsigned long fallocated_space, bool ignore_snap_errors){
+static int ioctl_transition_snap(unsigned int minor, const char *cow_path, unsigned long fallocated_space){
 	int ret;
 	struct snap_device *dev;
 
@@ -5089,10 +5089,10 @@ static long ctrl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg){
 		break;
 	case IOCTL_TRANSITION_SNAP:
 		//get params from user space
-		ret = get_transition_snap_params((struct transition_snap_params __user *)arg, &minor, &cow_path, &fallocated_space, &ignore_snap_errors);
+		ret = get_transition_snap_params((struct transition_snap_params __user *)arg, &minor, &cow_path, &fallocated_space);
 		if(ret) break;
 
-		ret = ioctl_transition_snap(minor, cow_path, fallocated_space, ignore_snap_errors);
+		ret = ioctl_transition_snap(minor, cow_path, fallocated_space);
 		if(ret) break;
 
 		break;

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -1294,12 +1294,12 @@ error:
 	return ret;
 }
 
-static int get_setup_params(const struct setup_params __user *in, unsigned int *minor, char **bdev_name, char **cow_path, unsigned long *fallocated_space, unsigned long *cache_size, bool *ignore_snap_errors){
+static int get_setup_params(const struct setup_params __user *in, unsigned int *minor, char **bdev_name, char **cow_path, unsigned long *fallocated_space, unsigned long *cache_size, bool *ignore_snap_errors, bool old_struct){
 	int ret;
 	struct setup_params params;
 
 	//copy the params struct
-	ret = copy_from_user(&params, in, sizeof(struct setup_params));
+	ret = copy_from_user(&params, in, old_struct ? sizeof(struct setup_params_v0_11_1) : sizeof(struct setup_params));
 	if(ret){
 		ret = -EFAULT;
 		LOG_ERROR(ret, "error copying setup_params struct from user space");
@@ -1327,7 +1327,7 @@ static int get_setup_params(const struct setup_params __user *in, unsigned int *
 	*minor = params.minor;
 	*fallocated_space = params.fallocated_space;
 	*cache_size = params.cache_size;
-	*ignore_snap_errors = params.ignore_snap_errors;
+	*ignore_snap_errors = old_struct ? true : params.ignore_snap_errors;
 	return 0;
 
 error:
@@ -1344,12 +1344,12 @@ error:
 	return ret;
 }
 
-static int get_reload_params(const struct reload_params __user *in, unsigned int *minor, char **bdev_name, char **cow_path, unsigned long *cache_size, bool *ignore_snap_errors){
+static int get_reload_params(const struct reload_params __user *in, unsigned int *minor, char **bdev_name, char **cow_path, unsigned long *cache_size, bool *ignore_snap_errors, bool old_struct){
 	int ret;
 	struct reload_params params;
 
 	//copy the params struct
-	ret = copy_from_user(&params, in, sizeof(struct reload_params));
+	ret = copy_from_user(&params, in, old_struct ? sizeof(struct reload_params_v0_11_1) : sizeof(struct reload_params));
 	if(ret){
 		ret = -EFAULT;
 		LOG_ERROR(ret, "error copying reload_params struct from user space");
@@ -1376,7 +1376,7 @@ static int get_reload_params(const struct reload_params __user *in, unsigned int
 
 	*minor = params.minor;
 	*cache_size = params.cache_size;
-	*ignore_snap_errors = params.ignore_snap_errors;
+	*ignore_snap_errors = old_struct ? true : params.ignore_snap_errors;
 	return 0;
 
 error:
@@ -4765,6 +4765,27 @@ static void tracer_elastio_snap_info(const struct snap_device *dev, struct elast
 	}
 }
 
+static void tracer_elastio_snap_info_v0_11_1(const struct snap_device *dev, struct elastio_snap_info_v0_11_1 *info){
+	info->minor = dev->sd_minor;
+	info->state = dev->sd_state;
+	info->error = tracer_read_fail_state(dev);
+	info->cache_size = (dev->sd_cache_size)? dev->sd_cache_size : elastio_snap_cow_max_memory_default;
+	strlcpy(info->cow, dev->sd_cow_path, PATH_MAX);
+	strlcpy(info->bdev, dev->sd_bdev_path, PATH_MAX);
+
+	if(!test_bit(UNVERIFIED, &dev->sd_state)){
+		info->falloc_size = dev->sd_cow->file_max;
+		info->seqid = dev->sd_cow->seqid;
+		memcpy(info->uuid, dev->sd_cow->uuid, COW_UUID_SIZE);
+		info->version = dev->sd_cow->version;
+		info->nr_changed_blocks = dev->sd_cow->nr_changed_blocks;
+	}else{
+		info->falloc_size = 0;
+		info->seqid = 0;
+		memset(info->uuid, 0, COW_UUID_SIZE);
+	}
+}
+
 /************************IOCTL HANDLER FUNCTIONS************************/
 
 static int __verify_minor(unsigned int minor, int mode){
@@ -5003,19 +5024,25 @@ error:
 	return ret;
 }
 
-static int ioctl_elastio_snap_info(struct elastio_snap_info *info){
+static int ioctl_elastio_snap_info(void *info, bool old_struct){
 	int ret;
 	struct snap_device *dev;
+	int minor;
 
-	LOG_DEBUG("received elastio-snap info ioctl - %u", info->minor);
+	minor = old_struct ? ((struct elastio_snap_info_v0_11_1 *)info)->minor : ((struct elastio_snap_info*)info)->minor;
+
+	LOG_DEBUG("received elastio-snap info ioctl - %u", minor);
 
 	//verify that the minor number is valid
-	ret = verify_minor_in_use(info->minor);
+	ret = verify_minor_in_use(minor);
 	if(ret) goto error;
 
-	dev = snap_devices[info->minor];
+	dev = snap_devices[minor];
 
-	tracer_elastio_snap_info(dev, info);
+	if (old_struct)
+		tracer_elastio_snap_info_v0_11_1(dev, (struct elastio_snap_info_v0_11_1 *)info);
+	else
+		tracer_elastio_snap_info(dev, (struct elastio_snap_info *)info);
 
 	return 0;
 
@@ -5040,7 +5067,7 @@ static long ctrl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg){
 	int ret, idx;
 	char *bdev_path = NULL;
 	char *cow_path = NULL;
-	struct elastio_snap_info *info = NULL;
+	void *info = NULL;
 	unsigned int minor = 0;
 	unsigned long fallocated_space = 0, cache_size = 0;
 	bool ignore_snap_errors = false;
@@ -5050,8 +5077,9 @@ static long ctrl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg){
 
 	switch(cmd){
 	case IOCTL_SETUP_SNAP:
+	case IOCTL_SETUP_SNAP_v0_11_1:
 		//get params from user space
-		ret = get_setup_params((struct setup_params __user *)arg, &minor, &bdev_path, &cow_path, &fallocated_space, &cache_size, &ignore_snap_errors);
+		ret = get_setup_params((struct setup_params __user *)arg, &minor, &bdev_path, &cow_path, &fallocated_space, &cache_size, &ignore_snap_errors, cmd == IOCTL_SETUP_SNAP_v0_11_1);
 		if(ret) break;
 
 		ret = ioctl_setup_snap(minor, bdev_path, cow_path, fallocated_space, cache_size, ignore_snap_errors);
@@ -5061,8 +5089,9 @@ static long ctrl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg){
 
 		break;
 	case IOCTL_RELOAD_SNAP:
+	case IOCTL_RELOAD_SNAP_v0_11_1:
 		//get params from user space
-		ret = get_reload_params((struct reload_params __user *)arg, &minor, &bdev_path, &cow_path, &cache_size, &ignore_snap_errors);
+		ret = get_reload_params((struct reload_params __user *)arg, &minor, &bdev_path, &cow_path, &cache_size, &ignore_snap_errors, cmd == IOCTL_RELOAD_SNAP_v0_11_1);
 		if(ret) break;
 
 		ret = ioctl_reload_snap(minor, bdev_path, cow_path, cache_size, ignore_snap_errors);
@@ -5070,8 +5099,9 @@ static long ctrl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg){
 
 		break;
 	case IOCTL_RELOAD_INC:
+	case IOCTL_RELOAD_INC_v0_11_1:
 		//get params from user space
-		ret = get_reload_params((struct reload_params __user *)arg, &minor, &bdev_path, &cow_path, &cache_size, &ignore_snap_errors);
+		ret = get_reload_params((struct reload_params __user *)arg, &minor, &bdev_path, &cow_path, &cache_size, &ignore_snap_errors, cmd == IOCTL_RELOAD_INC_v0_11_1);
 		if(ret) break;
 
 		ret = ioctl_reload_inc(minor, bdev_path, cow_path, cache_size, ignore_snap_errors);
@@ -5121,25 +5151,30 @@ static long ctrl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg){
 
 		break;
 	case IOCTL_ELASTIO_SNAP_INFO:
+	case IOCTL_ELASTIO_SNAP_INFO_v0_11_1:
 		//get params from user space
-		info = kmalloc(sizeof(struct elastio_snap_info), GFP_KERNEL);
+		info = kmalloc(cmd == IOCTL_ELASTIO_SNAP_INFO ? sizeof(struct elastio_snap_info) : sizeof(struct elastio_snap_info_v0_11_1), GFP_KERNEL);
 		if(!info){
 			ret = -ENOMEM;
 			LOG_ERROR(ret, "error allocating memory for elastio-snap-info");
 			break;
 		}
 
-		ret = copy_from_user(info, (struct elastio_snap_info __user *)arg, sizeof(struct elastio_snap_info));
+		ret = cmd == IOCTL_ELASTIO_SNAP_INFO ?
+			copy_from_user(info, (struct elastio_snap_info __user *)arg, sizeof(struct elastio_snap_info)) :
+			copy_from_user(info, (struct elastio_snap_info_v0_11_1 __user *)arg, sizeof(struct elastio_snap_info_v0_11_1));
 		if(ret){
 			ret = -EFAULT;
 			LOG_ERROR(ret, "error copying elastio-snap-info struct from user space");
 			break;
 		}
 
-		ret = ioctl_elastio_snap_info(info);
+		ret = ioctl_elastio_snap_info(info, cmd == IOCTL_ELASTIO_SNAP_INFO_v0_11_1);
 		if(ret) break;
 
-		ret = copy_to_user((struct elastio_snap_info __user *)arg, info, sizeof(struct elastio_snap_info));
+		ret = cmd == IOCTL_ELASTIO_SNAP_INFO ?
+			copy_to_user((struct elastio_snap_info __user *)arg, info, sizeof(struct elastio_snap_info)) :
+			copy_to_user((struct elastio_snap_info_v0_11_1 __user *)arg, info, sizeof(struct elastio_snap_info_v0_11_1));
 		if(ret){
 			ret = -EFAULT;
 			LOG_ERROR(ret, "error copying elastio-snap-info struct to user space");

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -1339,6 +1339,7 @@ error:
 	*minor = 0;
 	*fallocated_space = 0;
 	*cache_size = 0;
+	*ignore_snap_errors = false;
 	return ret;
 }
 
@@ -1386,6 +1387,7 @@ error:
 	*cow_path = NULL;
 	*minor = 0;
 	*cache_size = 0;
+	*ignore_snap_errors = false;
 	return ret;
 }
 

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -4748,6 +4748,7 @@ static void tracer_elastio_snap_info(const struct snap_device *dev, struct elast
 	info->state = dev->sd_state;
 	info->error = tracer_read_fail_state(dev);
 	info->cache_size = (dev->sd_cache_size)? dev->sd_cache_size : elastio_snap_cow_max_memory_default;
+	info->ignore_snap_errors = dev->sd_ignore_snap_errors;
 	strlcpy(info->cow, dev->sd_cow_path, PATH_MAX);
 	strlcpy(info->bdev, dev->sd_bdev_path, PATH_MAX);
 
@@ -4762,7 +4763,6 @@ static void tracer_elastio_snap_info(const struct snap_device *dev, struct elast
 		info->seqid = 0;
 		memset(info->uuid, 0, COW_UUID_SIZE);
 	}
-	info->ignore_snap_errors = dev->sd_ignore_snap_errors;
 }
 
 /************************IOCTL HANDLER FUNCTIONS************************/
@@ -4827,7 +4827,7 @@ static int __ioctl_setup(unsigned int minor, const char *bdev_path, const char *
 	int ret, is_mounted;
 	struct snap_device *dev = NULL;
 
-	LOG_DEBUG("received %s %s ioctl - %u : %s : %s: %s", (is_reload)? "reload" : "setup", (is_snap)? "snap" : "inc", minor, bdev_path, cow_path, (ignore_snap_errors)? "ignore_errors" : "no_ignore_errors");
+	LOG_DEBUG("received %s %s ioctl - %u : %s : %s : %s", (is_reload)? "reload" : "setup", (is_snap)? "snap" : "inc", minor, bdev_path, cow_path, (ignore_snap_errors)? "ignore_errors" : "no_ignore_errors");
 
 	//verify that the minor number is valid
 	ret = verify_minor_available(minor);
@@ -6025,8 +6025,8 @@ static int elastio_snap_proc_show(struct seq_file *m, void *v){
 		error = tracer_read_fail_state(dev);
 		if(error) seq_printf(m, "\t\t\t\"error\": %d,\n", error);
 
-		seq_printf(m, "\t\t\t\"state\": %lu\n", dev->sd_state);
-		seq_printf(m, "\t\t\t\"ignore_error\": %i\n", dev->sd_ignore_snap_errors);
+		seq_printf(m, "\t\t\t\"state\": %lu,\n", dev->sd_state);
+		seq_printf(m, "\t\t\t\"ignore_errors\": %i\n", dev->sd_ignore_snap_errors);
 		seq_printf(m, "\t\t}");
 	}
 

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -6012,6 +6012,7 @@ static int elastio_snap_proc_show(struct seq_file *m, void *v){
 		if(error) seq_printf(m, "\t\t\t\"error\": %d,\n", error);
 
 		seq_printf(m, "\t\t\t\"state\": %lu\n", dev->sd_state);
+		seq_printf(m, "\t\t\t\"ignore_error\": %i\n", dev->sd_ignore_snap_errors);
 		seq_printf(m, "\t\t}");
 	}
 

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -1342,7 +1342,7 @@ error:
 	return ret;
 }
 
-static int get_reload_params(const struct reload_params __user *in, unsigned int *minor, char **bdev_name, char **cow_path, unsigned long *cache_size){
+static int get_reload_params(const struct reload_params __user *in, unsigned int *minor, char **bdev_name, char **cow_path, unsigned long *cache_size, bool *ignore_snap_errors){
 	int ret;
 	struct reload_params params;
 
@@ -1374,6 +1374,7 @@ static int get_reload_params(const struct reload_params __user *in, unsigned int
 
 	*minor = params.minor;
 	*cache_size = params.cache_size;
+	*ignore_snap_errors = params.ignore_snap_errors;
 	return 0;
 
 error:
@@ -4859,9 +4860,8 @@ error:
 	return ret;
 }
 #define ioctl_setup_snap(minor, bdev_path, cow_path, fallocated_space, cache_size, ignore_snap_errors) __ioctl_setup(minor, bdev_path, cow_path, fallocated_space, cache_size, ignore_snap_errors, 1, 0)
-// TODO: think do I need to add ignore_snap_errors real value from userspace to the funcs below instead of 0
-#define ioctl_reload_snap(minor, bdev_path, cow_path, cache_size) __ioctl_setup(minor, bdev_path, cow_path, 0, cache_size, 0, 1, 1)
-#define ioctl_reload_inc(minor, bdev_path, cow_path, cache_size) __ioctl_setup(minor, bdev_path, cow_path, 0, cache_size, 0, 0, 1)
+#define ioctl_reload_snap(minor, bdev_path, cow_path, cache_size, ignore_snap_errors) __ioctl_setup(minor, bdev_path, cow_path, 0, cache_size, ignore_snap_errors, 1, 1)
+#define ioctl_reload_inc(minor, bdev_path, cow_path, cache_size, ignore_snap_errors) __ioctl_setup(minor, bdev_path, cow_path, 0, cache_size, ignore_snap_errors, 0, 1)
 
 static int ioctl_destroy(unsigned int minor){
 	int ret;
@@ -5047,19 +5047,19 @@ static long ctrl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg){
 		break;
 	case IOCTL_RELOAD_SNAP:
 		//get params from user space
-		ret = get_reload_params((struct reload_params __user *)arg, &minor, &bdev_path, &cow_path, &cache_size);
+		ret = get_reload_params((struct reload_params __user *)arg, &minor, &bdev_path, &cow_path, &cache_size, &ignore_snap_errors);
 		if(ret) break;
 
-		ret = ioctl_reload_snap(minor, bdev_path, cow_path, cache_size);
+		ret = ioctl_reload_snap(minor, bdev_path, cow_path, cache_size, ignore_snap_errors);
 		if(ret) break;
 
 		break;
 	case IOCTL_RELOAD_INC:
 		//get params from user space
-		ret = get_reload_params((struct reload_params __user *)arg, &minor, &bdev_path, &cow_path, &cache_size);
+		ret = get_reload_params((struct reload_params __user *)arg, &minor, &bdev_path, &cow_path, &cache_size, &ignore_snap_errors);
 		if(ret) break;
 
-		ret = ioctl_reload_inc(minor, bdev_path, cow_path, cache_size);
+		ret = ioctl_reload_inc(minor, bdev_path, cow_path, cache_size, ignore_snap_errors);
 		if(ret) break;
 
 		break;

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -3248,14 +3248,10 @@ static int snap_cow_thread(void *data){
 				continue;
 			}
 
-			// handle write bio in all cases except just when an error have to be ignored and the snapshot is in the error state
-			if (!dev->sd_ignore_snap_errors || tracer_read_fail_state(dev) == 0)
-			{
-				ret = snap_handle_write_bio(dev, bio);
-				if (ret) {
-					LOG_ERROR(ret, "error handling write bio in kernel thread");
-					tracer_set_fail_state(dev, ret);
-				}
+			ret = snap_handle_write_bio(dev, bio);
+			if (ret) {
+				LOG_ERROR(ret, "error handling write bio in kernel thread");
+				tracer_set_fail_state(dev, ret);
 			}
 
 			atomic64_inc(&dev->sd_processed_cnt);

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -3417,9 +3417,10 @@ static int memory_is_too_low(struct snap_device *dev) {
 		totalram = si.totalram;
 	}
 
-	ret = ((si_mem_available() * 100) / totalram) < LOW_MEMORY_FAIL_PERCENT ? -ENOMEM : tracer_read_fail_state(dev);
-	if (ret && tracer_read_fail_state(dev) != -ENOMEM) {
+	ret = tracer_read_fail_state(dev);
+	if (ret == 0 && ((si_mem_available() * 100) / totalram) < LOW_MEMORY_FAIL_PERCENT) {
 		LOG_WARN("physical memory usage has exceeded %d%% threshold. cow file update is stopped", (100 - LOW_MEMORY_FAIL_PERCENT));
+		ret = -ENOMEM;
 		tracer_set_fail_state(dev, ret);
 	}
 	return ret;

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -3658,7 +3658,7 @@ static MRF_RETURN_TYPE snap_mrf(struct bio *bio){
 		elastio_snap_bio_endio(bio, -EOPNOTSUPP);
 		MRF_RETURN(0);
 	}else if(tracer_read_fail_state(dev)){
-		elastio_snap_bio_endio(bio, -EIO);
+		elastio_snap_bio_endio(bio, wrap_err_io(dev));
 		MRF_RETURN(0);
 	}else if(!test_bit(ACTIVE, &dev->sd_state)){
 		elastio_snap_bio_endio(bio, -EBUSY);

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -3423,7 +3423,7 @@ static inline void wait_for_bio_complete(struct snap_device *dev)
 			atomic64_read(&dev->sd_submitted_cnt) == atomic64_read(&dev->sd_processed_cnt),
 			msecs_to_jiffies(WAIT_SUBMITTED_BIOS_MSEC))) {
 		LOG_WARN("failed wait for all submitted BIOs to be processed after %d ms. bio submitted = %lld, bio processed = %lld",
-				WAIT_SUBMITTED_BIOS_MSEC, (uint64_t) atomic64_read(&dev->sd_submitted_cnt), (uint64_t) atomic64_read(&dev->sd_processed_cnt));
+				WAIT_SUBMITTED_BIOS_MSEC, (u64)atomic64_read(&dev->sd_submitted_cnt), (u64)atomic64_read(&dev->sd_processed_cnt));
 	}
 }
 

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -3437,7 +3437,7 @@ static int snap_trace_bio(struct snap_device *dev, struct bio *bio){
 	//if we don't need to cow this bio or if the snapshot is in the failed state,
 	//e.g. physical memory usage has exceeded threshold or COW file state is failed,
 	//just call the real mrf normally
-	if (!bio_needs_cow(bio, dev) || memory_is_too_low(dev) || (dev->sd_ignore_snap_errors && tracer_read_fail_state(dev))) {
+	if (!bio_needs_cow(bio, dev) || memory_is_too_low(dev) || tracer_read_fail_state(dev)) {
 		return elastio_snap_call_mrf(dev->sd_orig_mrf, bio);
 	}
 

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -1267,6 +1267,7 @@ static inline void tracer_set_fail_state(struct snap_device *dev, int error){
 static inline int wrap_err_io(struct snap_device *dev){
     return !dev->sd_ignore_snap_errors ? -EIO : 0;
 }
+
 /************************IOCTL COPY FROM USER FUNCTIONS************************/
 
 static int copy_string_from_user(const char __user *data, char **out_ptr){
@@ -3435,7 +3436,7 @@ static int memory_is_too_low(struct snap_device *dev) {
 	}
 
 	ret = tracer_read_fail_state(dev);
-	if (ret == 0 && ((si_mem_available() * 100) / totalram) < LOW_MEMORY_FAIL_PERCENT) {
+	if (ret != -ENOMEM && ((si_mem_available() * 100) / totalram) < LOW_MEMORY_FAIL_PERCENT) {
 		LOG_WARN("physical memory usage has exceeded %d%% threshold. cow file update is stopped", (100 - LOW_MEMORY_FAIL_PERCENT));
 		ret = -ENOMEM;
 		tracer_set_fail_state(dev, ret);

--- a/src/elastio-snap.h
+++ b/src/elastio-snap.h
@@ -97,14 +97,57 @@ struct elastio_snap_info{
 	                         //it should be not 0 if a snap device is used as a memory-mapped file
 };
 
-#define IOCTL_SETUP_SNAP _IOW(ELASTIO_IOCTL_MAGIC, 1, struct setup_params) //in: see above
-#define IOCTL_RELOAD_SNAP _IOW(ELASTIO_IOCTL_MAGIC, 2, struct reload_params) //in: see above
-#define IOCTL_RELOAD_INC _IOW(ELASTIO_IOCTL_MAGIC, 3, struct reload_params) //in: see above
+#define IOCTL_SETUP_SNAP _IOW(ELASTIO_IOCTL_MAGIC, 11, struct setup_params) //in: see above
+#define IOCTL_RELOAD_SNAP _IOW(ELASTIO_IOCTL_MAGIC, 12, struct reload_params) //in: see above
+#define IOCTL_RELOAD_INC _IOW(ELASTIO_IOCTL_MAGIC, 13, struct reload_params) //in: see above
 #define IOCTL_DESTROY _IOW(ELASTIO_IOCTL_MAGIC, 4, unsigned int) //in: minor
 #define IOCTL_TRANSITION_INC _IOW(ELASTIO_IOCTL_MAGIC, 5, unsigned int) //in: minor
 #define IOCTL_TRANSITION_SNAP _IOW(ELASTIO_IOCTL_MAGIC, 6, struct transition_snap_params) //in: see above
 #define IOCTL_RECONFIGURE _IOW(ELASTIO_IOCTL_MAGIC, 7, struct reconfigure_params) //in: see above
-#define IOCTL_ELASTIO_SNAP_INFO _IOR(ELASTIO_IOCTL_MAGIC, 8, struct elastio_snap_info) //in: see above
+#define IOCTL_ELASTIO_SNAP_INFO _IOR(ELASTIO_IOCTL_MAGIC, 18, struct elastio_snap_info) //in: see above
 #define IOCTL_GET_FREE _IOR(ELASTIO_IOCTL_MAGIC, 9, int)
+
+// Old structures for the backward compatibility of an old library v.0.11.1 and older and new
+// driver v.0.12.0 and newer. They do not contain 'ignore_snap_errors' member.
+struct setup_params_v0_11_1{
+	char *bdev; //name of block device to snapshot
+	char *cow; //name of cow file for snapshot
+	unsigned long fallocated_space; //space allocated to the cow file (in megabytes)
+	unsigned long cache_size; //maximum cache size (in bytes)
+	unsigned int minor; //requested minor number of the device
+};
+
+struct reload_params_v0_11_1{
+	char *bdev; //name of block device to snapshot
+	char *cow; //name of cow file for snapshot
+	unsigned long cache_size; //maximum cache size (in bytes)
+	unsigned int minor; //requested minor number of the device
+};
+
+struct elastio_snap_info_v0_11_1{
+	unsigned int minor;
+	unsigned long state;
+	int error;
+	unsigned long cache_size;
+	unsigned long long falloc_size;
+	unsigned long long seqid;
+	char uuid[COW_UUID_SIZE];
+	char cow[PATH_MAX];
+	char bdev[PATH_MAX];
+	unsigned long long version;
+	unsigned long long nr_changed_blocks;
+};
+
+/* Old IOCTLs for the backward compatibility of the new driver with an old library v.0.11.1 and older.
+ * The lib and driver should be always the same version. And it's easy to get having separate repositories for
+ * 'master' and 'release' in elastio and elastio-snap.
+ * That's why this is probably not necessary for the majority of the elastio-snap users.
+ * But the codes of 4 IOCTls are changed for easer usage and update of Elastio and/or elastio-snap
+ * to approach this backward compatibility.... Life is embarrassing.
+ */
+#define IOCTL_SETUP_SNAP_v0_11_1 _IOW(ELASTIO_IOCTL_MAGIC, 1, struct setup_params_v0_11_1) //in: see above
+#define IOCTL_RELOAD_SNAP_v0_11_1 _IOW(ELASTIO_IOCTL_MAGIC, 2, struct reload_params_v0_11_1) //in: see above
+#define IOCTL_RELOAD_INC_v0_11_1 _IOW(ELASTIO_IOCTL_MAGIC, 3, struct reload_params_v0_11_1) //in: see above
+#define IOCTL_ELASTIO_SNAP_INFO_v0_11_1 _IOR(ELASTIO_IOCTL_MAGIC, 8, struct elastio_snap_info_v0_11_1) //in: see above
 
 #endif /* ELASTIO_SNAP_H_ */

--- a/src/elastio-snap.h
+++ b/src/elastio-snap.h
@@ -26,7 +26,7 @@ struct setup_params{
 	unsigned long cache_size; //maximum cache size (in bytes)
 	unsigned int minor; //requested minor number of the device
 	bool ignore_snap_errors; //whether or not to return EIO on read snap BIOs when a snap in a failed state
-							 //it should be not 0 if a snap device is used as a memory-mapped file
+	                         //it should be not 0 if a snap device is used as a memory-mapped file
 };
 
 struct reload_params{
@@ -35,7 +35,7 @@ struct reload_params{
 	unsigned long cache_size; //maximum cache size (in bytes)
 	unsigned int minor; //requested minor number of the device
 	bool ignore_snap_errors; //whether or not to return EIO on read snap BIOs when a snap in a failed state
-							 //it should be not 0 if a snap device is used as a memory-mapped file
+	                         //it should be not 0 if a snap device is used as a memory-mapped file
 
 };
 
@@ -94,7 +94,7 @@ struct elastio_snap_info{
 	unsigned long long version;
 	unsigned long long nr_changed_blocks;
 	bool ignore_snap_errors; //whether or not to return EIO on read snap BIOs when a snap in a failed state
-							 //it should be not 0 if a snap device is used as a memory-mapped file
+	                         //it should be not 0 if a snap device is used as a memory-mapped file
 };
 
 #define IOCTL_SETUP_SNAP _IOW(ELASTIO_IOCTL_MAGIC, 1, struct setup_params) //in: see above

--- a/src/elastio-snap.h
+++ b/src/elastio-snap.h
@@ -16,7 +16,7 @@
 #include <linux/ioctl.h>
 #include <linux/limits.h>
 
-#define ELASTIO_SNAP_VERSION "0.11.1"
+#define ELASTIO_SNAP_VERSION "0.12.0"
 #define ELASTIO_IOCTL_MAGIC 'A' // 0x41
 
 struct setup_params{

--- a/src/elastio-snap.h
+++ b/src/elastio-snap.h
@@ -34,6 +34,9 @@ struct reload_params{
 	char *cow; //name of cow file for snapshot
 	unsigned long cache_size; //maximum cache size (in bytes)
 	unsigned int minor; //requested minor number of the device
+	bool ignore_snap_errors; //whether or not to return EIO on read snap BIOs when a snap in a failed state
+							 //it should be not 0 if a snap device is used as a memory-mapped file
+
 };
 
 struct transition_snap_params{

--- a/src/elastio-snap.h
+++ b/src/elastio-snap.h
@@ -40,8 +40,6 @@ struct transition_snap_params{
 	char *cow; //name of cow file for snapshot
 	unsigned long fallocated_space; //space allocated to the cow file (in bytes)
 	unsigned int minor; //requested minor
-	bool ignore_snap_errors; //whether or not to return EIO on read snap BIOs when a snap in a failed state
-							 //it should be not 0 if a snap device is used as a memory-mapped file
 };
 
 struct reconfigure_params{

--- a/src/elastio-snap.h
+++ b/src/elastio-snap.h
@@ -97,57 +97,14 @@ struct elastio_snap_info{
 	                         //it should be not 0 if a snap device is used as a memory-mapped file
 };
 
-#define IOCTL_SETUP_SNAP _IOW(ELASTIO_IOCTL_MAGIC, 11, struct setup_params) //in: see above
-#define IOCTL_RELOAD_SNAP _IOW(ELASTIO_IOCTL_MAGIC, 12, struct reload_params) //in: see above
-#define IOCTL_RELOAD_INC _IOW(ELASTIO_IOCTL_MAGIC, 13, struct reload_params) //in: see above
+#define IOCTL_SETUP_SNAP _IOW(ELASTIO_IOCTL_MAGIC, 1, struct setup_params) //in: see above
+#define IOCTL_RELOAD_SNAP _IOW(ELASTIO_IOCTL_MAGIC, 2, struct reload_params) //in: see above
+#define IOCTL_RELOAD_INC _IOW(ELASTIO_IOCTL_MAGIC, 3, struct reload_params) //in: see above
 #define IOCTL_DESTROY _IOW(ELASTIO_IOCTL_MAGIC, 4, unsigned int) //in: minor
 #define IOCTL_TRANSITION_INC _IOW(ELASTIO_IOCTL_MAGIC, 5, unsigned int) //in: minor
 #define IOCTL_TRANSITION_SNAP _IOW(ELASTIO_IOCTL_MAGIC, 6, struct transition_snap_params) //in: see above
 #define IOCTL_RECONFIGURE _IOW(ELASTIO_IOCTL_MAGIC, 7, struct reconfigure_params) //in: see above
-#define IOCTL_ELASTIO_SNAP_INFO _IOR(ELASTIO_IOCTL_MAGIC, 18, struct elastio_snap_info) //in: see above
+#define IOCTL_ELASTIO_SNAP_INFO _IOR(ELASTIO_IOCTL_MAGIC, 8, struct elastio_snap_info) //in: see above
 #define IOCTL_GET_FREE _IOR(ELASTIO_IOCTL_MAGIC, 9, int)
-
-// Old structures for the backward compatibility of an old library v.0.11.1 and older and new
-// driver v.0.12.0 and newer. They do not contain 'ignore_snap_errors' member.
-struct setup_params_v0_11_1{
-	char *bdev; //name of block device to snapshot
-	char *cow; //name of cow file for snapshot
-	unsigned long fallocated_space; //space allocated to the cow file (in megabytes)
-	unsigned long cache_size; //maximum cache size (in bytes)
-	unsigned int minor; //requested minor number of the device
-};
-
-struct reload_params_v0_11_1{
-	char *bdev; //name of block device to snapshot
-	char *cow; //name of cow file for snapshot
-	unsigned long cache_size; //maximum cache size (in bytes)
-	unsigned int minor; //requested minor number of the device
-};
-
-struct elastio_snap_info_v0_11_1{
-	unsigned int minor;
-	unsigned long state;
-	int error;
-	unsigned long cache_size;
-	unsigned long long falloc_size;
-	unsigned long long seqid;
-	char uuid[COW_UUID_SIZE];
-	char cow[PATH_MAX];
-	char bdev[PATH_MAX];
-	unsigned long long version;
-	unsigned long long nr_changed_blocks;
-};
-
-/* Old IOCTLs for the backward compatibility of the new driver with an old library v.0.11.1 and older.
- * The lib and driver should be always the same version. And it's easy to get having separate repositories for
- * 'master' and 'release' in elastio and elastio-snap.
- * That's why this is probably not necessary for the majority of the elastio-snap users.
- * But the codes of 4 IOCTls are changed for easer usage and update of Elastio and/or elastio-snap
- * to approach this backward compatibility.... Life is embarrassing.
- */
-#define IOCTL_SETUP_SNAP_v0_11_1 _IOW(ELASTIO_IOCTL_MAGIC, 1, struct setup_params_v0_11_1) //in: see above
-#define IOCTL_RELOAD_SNAP_v0_11_1 _IOW(ELASTIO_IOCTL_MAGIC, 2, struct reload_params_v0_11_1) //in: see above
-#define IOCTL_RELOAD_INC_v0_11_1 _IOW(ELASTIO_IOCTL_MAGIC, 3, struct reload_params_v0_11_1) //in: see above
-#define IOCTL_ELASTIO_SNAP_INFO_v0_11_1 _IOR(ELASTIO_IOCTL_MAGIC, 8, struct elastio_snap_info_v0_11_1) //in: see above
 
 #endif /* ELASTIO_SNAP_H_ */

--- a/src/elastio-snap.h
+++ b/src/elastio-snap.h
@@ -24,6 +24,7 @@ struct setup_params{
 	unsigned long fallocated_space; //space allocated to the cow file (in megabytes)
 	unsigned long cache_size; //maximum cache size (in bytes)
 	unsigned int minor; //requested minor number of the device
+	unsigned int allow_mem_mapping; //whether or not to return EIO on read snap bios when a snap in a failed state. should be not 0 if a snap device is used as memory-mapped file
 };
 
 struct reload_params{
@@ -37,6 +38,7 @@ struct transition_snap_params{
 	char *cow; //name of cow file for snapshot
 	unsigned long fallocated_space; //space allocated to the cow file (in bytes)
 	unsigned int minor; //requested minor
+	unsigned int allow_mem_mapping; //whether or not to return EIO on read snap bios when a snap in a failed state. should be not 0 if a snap device is used as memory-mapped file
 };
 
 struct reconfigure_params{

--- a/src/elastio-snap.h
+++ b/src/elastio-snap.h
@@ -93,6 +93,8 @@ struct elastio_snap_info{
 	char bdev[PATH_MAX];
 	unsigned long long version;
 	unsigned long long nr_changed_blocks;
+	bool ignore_snap_errors; //whether or not to return EIO on read snap BIOs when a snap in a failed state
+							 //it should be not 0 if a snap device is used as a memory-mapped file
 };
 
 #define IOCTL_SETUP_SNAP _IOW(ELASTIO_IOCTL_MAGIC, 1, struct setup_params) //in: see above

--- a/src/elastio-snap.h
+++ b/src/elastio-snap.h
@@ -10,6 +10,7 @@
 
 #ifndef __KERNEL__
 #include <stdint.h>
+#include <stdbool.h>
 #endif
 
 #include <linux/ioctl.h>
@@ -24,7 +25,8 @@ struct setup_params{
 	unsigned long fallocated_space; //space allocated to the cow file (in megabytes)
 	unsigned long cache_size; //maximum cache size (in bytes)
 	unsigned int minor; //requested minor number of the device
-	unsigned int allow_mem_mapping; //whether or not to return EIO on read snap bios when a snap in a failed state. should be not 0 if a snap device is used as memory-mapped file
+	bool ignore_snap_errors; //whether or not to return EIO on read snap BIOs when a snap in a failed state
+							 //it should be not 0 if a snap device is used as a memory-mapped file
 };
 
 struct reload_params{
@@ -38,7 +40,8 @@ struct transition_snap_params{
 	char *cow; //name of cow file for snapshot
 	unsigned long fallocated_space; //space allocated to the cow file (in bytes)
 	unsigned int minor; //requested minor
-	unsigned int allow_mem_mapping; //whether or not to return EIO on read snap bios when a snap in a failed state. should be not 0 if a snap device is used as memory-mapped file
+	bool ignore_snap_errors; //whether or not to return EIO on read snap BIOs when a snap in a failed state
+							 //it should be not 0 if a snap device is used as a memory-mapped file
 };
 
 struct reconfigure_params{

--- a/tests/elastio_snap.py
+++ b/tests/elastio_snap.py
@@ -6,10 +6,6 @@
 #
 
 from cffi import FFI
-import sys
-if sys.version_info >= (3, 6):
-    from enum import IntFlag
-
 import util
 
 ffi = FFI()
@@ -51,16 +47,12 @@ int elastio_snap_get_free_minor(void);
 
 lib = ffi.dlopen("../lib/libelastio-snap.so")
 
-if sys.version_info >= (3, 6):
-    class State(IntFlag):
-        SNAPSHOT = 1
-        ACTIVE = 2
-        UNVERIFIED = 4
-else:
-    class State:
-        SNAPSHOT = 1
-        ACTIVE = 2
-        UNVERIFIED = 4
+# It could be "class State(IntFlag):", but "IntFlag" was introduced in class "enum" of the Python 3.6,
+# which isn't present on Debian 9 and CentOS 7.
+class State:
+    SNAPSHOT = 1
+    ACTIVE = 2
+    UNVERIFIED = 4
 
 def setup(minor, device, cow_file, fallocated_space=0, cache_size=0, ignore_snap_errors=False):
     ret = lib.elastio_snap_setup_snapshot(

--- a/tests/elastio_snap.py
+++ b/tests/elastio_snap.py
@@ -6,7 +6,9 @@
 #
 
 from cffi import FFI
-from enum import IntFlag
+import sys
+if sys.version_info >= (3, 6):
+    from enum import IntFlag
 
 import util
 
@@ -49,10 +51,16 @@ int elastio_snap_get_free_minor(void);
 
 lib = ffi.dlopen("../lib/libelastio-snap.so")
 
-class State(IntFlag):
-    SNAPSHOT = 1
-    ACTIVE = 2
-    UNVERIFIED = 4
+if sys.version_info >= (3, 6):
+    class State(IntFlag):
+        SNAPSHOT = 1
+        ACTIVE = 2
+        UNVERIFIED = 4
+else:
+    class State:
+        SNAPSHOT = 1
+        ACTIVE = 2
+        UNVERIFIED = 4
 
 def setup(minor, device, cow_file, fallocated_space=0, cache_size=0, ignore_snap_errors=False):
     ret = lib.elastio_snap_setup_snapshot(

--- a/tests/elastio_snap.py
+++ b/tests/elastio_snap.py
@@ -27,11 +27,12 @@ struct elastio_snap_info {
     char bdev[PATH_MAX];
     unsigned long long version;
     unsigned long long nr_changed_blocks;
+    bool ignore_snap_errors;
 };
 
-int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long fallocated_space, unsigned long cache_size);
-int elastio_snap_reload_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long cache_size);
-int elastio_snap_reload_incremental(unsigned int minor, char *bdev, char *cow, unsigned long cache_size);
+int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long fallocated_space, unsigned long cache_size, bool ignore_snap_errors);
+int elastio_snap_reload_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long cache_size, bool ignore_snap_errors);
+int elastio_snap_reload_incremental(unsigned int minor, char *bdev, char *cow, unsigned long cache_size, bool ignore_snap_errors);
 int elastio_snap_destroy(unsigned int minor);
 int elastio_snap_transition_incremental(unsigned int minor);
 int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space);
@@ -43,13 +44,14 @@ int elastio_snap_get_free_minor(void);
 lib = ffi.dlopen("../lib/libelastio-snap.so")
 
 
-def setup(minor, device, cow_file, fallocated_space=0, cache_size=0):
+def setup(minor, device, cow_file, fallocated_space=0, cache_size=0, ignore_snap_errors=False):
     ret = lib.elastio_snap_setup_snapshot(
         minor,
         device.encode("utf-8"),
         cow_file.encode("utf-8"),
         fallocated_space,
-        cache_size
+        cache_size,
+        ignore_snap_errors
     )
 
     if ret != 0:
@@ -59,12 +61,13 @@ def setup(minor, device, cow_file, fallocated_space=0, cache_size=0):
     return 0
 
 
-def reload_snapshot(minor, device, cow_file, cache_size=0):
+def reload_snapshot(minor, device, cow_file, cache_size=0, ignore_snap_errors=False):
     ret = lib.elastio_snap_reload_snapshot(
         minor,
         device.encode("utf-8"),
         cow_file.encode("utf-8"),
-        cache_size
+        cache_size,
+        ignore_snap_errors
     )
 
     if ret != 0:
@@ -74,12 +77,13 @@ def reload_snapshot(minor, device, cow_file, cache_size=0):
     return 0
 
 
-def reload_incremental(minor, device, cow_file, cache_size=0):
+def reload_incremental(minor, device, cow_file, cache_size=0, ignore_snap_errors=False):
     ret = lib.elastio_snap_reload_incremental(
         minor,
         device.encode("utf-8"),
         cow_file.encode("utf-8"),
-        cache_size
+        cache_size,
+        ignore_snap_errors
     )
 
     if ret != 0:
@@ -150,6 +154,7 @@ def info(minor):
         "bdev": ffi.string(di.bdev).decode("utf-8"),
         "version": di.version,
         "nr_changed_blocks": di.nr_changed_blocks,
+        "ignore_snap_errors": di.ignore_snap_errors
     }
 
 def get_free_minor():

--- a/tests/elastio_snap.py
+++ b/tests/elastio_snap.py
@@ -6,6 +6,7 @@
 #
 
 from cffi import FFI
+from enum import IntFlag
 
 import util
 
@@ -14,6 +15,11 @@ ffi = FFI()
 ffi.cdef("""
 #define COW_UUID_SIZE 16
 #define PATH_MAX 4096
+
+//macros for defining the state of a tracing struct (bit offsets)
+#define SNAPSHOT 0
+#define ACTIVE 1
+#define UNVERIFIED 2
 
 struct elastio_snap_info {
     unsigned int minor;
@@ -43,6 +49,10 @@ int elastio_snap_get_free_minor(void);
 
 lib = ffi.dlopen("../lib/libelastio-snap.so")
 
+class State(IntFlag):
+    SNAPSHOT = 1
+    ACTIVE = 2
+    UNVERIFIED = 4
 
 def setup(minor, device, cow_file, fallocated_space=0, cache_size=0, ignore_snap_errors=False):
     ret = lib.elastio_snap_setup_snapshot(

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -42,7 +42,7 @@ class TestMultipart(DeviceTestCaseMultipart):
             self.assertIsNotNone(snapdev)
 
             self.assertEqual(snapdev["error"], 0)
-            self.assertEqual(snapdev["state"], 3)
+            self.assertEqual(snapdev["state"], elastio_snap.State.ACTIVE | elastio_snap.State.SNAPSHOT)
             self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
             self.assertEqual(snapdev["bdev"], self.devices[i])
             self.assertEqual(snapdev["version"], 1)

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -86,6 +86,7 @@ class TestReload(DeviceTestCase):
         self.check_snap_info(-errno.ENOENT, elastio_snap.State.UNVERIFIED, True)
 
 
+    @unittest.skipIf(os.getenv('TEST_FS') == "ext2" and int(platform.release().split(".", 1)[0]) < 4, "Broken on ext2, 3-rd kernels")
     def test_reload_verified_snapshot(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path, ignore_snap_errors=True), 0)
 

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -51,6 +51,7 @@ class TestReload(DeviceTestCase):
         self.assertFalse(os.path.exists(self.snap_device))
         self.assertIsNone(elastio_snap.info(self.minor))
 
+
     def test_reload_unverified_snapshot(self):
         util.unmount(self.mount)
         self.addCleanup(util.mount, self.device, self.mount)
@@ -59,31 +60,13 @@ class TestReload(DeviceTestCase):
         self.addCleanup(elastio_snap.destroy, self.minor)
         self.assertFalse(os.path.exists(self.snap_device))
 
-        snapdev = elastio_snap.info(self.minor)
-        self.assertIsNotNone(snapdev)
-
-        self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], elastio_snap.State.UNVERIFIED | elastio_snap.State.SNAPSHOT)
-        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
-        self.assertEqual(snapdev["bdev"], self.device)
-        self.assertEqual(snapdev["version"], 0)
-        self.assertEqual(snapdev["falloc_size"], 0)
-        self.assertEqual(snapdev["ignore_snap_errors"], True)
+        self.check_snap_info(0, elastio_snap.State.UNVERIFIED | elastio_snap.State.SNAPSHOT, True)
 
         # Mount and test that the non-existent cow file been handled
         util.mount(self.device, self.mount)
         self.addCleanup(util.unmount, self.device, self.mount)
 
-        snapdev = elastio_snap.info(self.minor)
-        self.assertIsNotNone(snapdev)
-
-        self.assertEqual(snapdev["error"], -errno.ENOENT)
-        self.assertEqual(snapdev["state"], elastio_snap.State.UNVERIFIED | elastio_snap.State.SNAPSHOT)
-        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
-        self.assertEqual(snapdev["bdev"], self.device)
-        self.assertEqual(snapdev["version"], 0)
-        self.assertEqual(snapdev["falloc_size"], 0)
-        self.assertEqual(snapdev["ignore_snap_errors"], True)
+        self.check_snap_info(-errno.ENOENT, elastio_snap.State.UNVERIFIED | elastio_snap.State.SNAPSHOT, True)
 
 
     def test_reload_unverified_incremental(self):
@@ -94,31 +77,14 @@ class TestReload(DeviceTestCase):
         self.addCleanup(elastio_snap.destroy, self.minor)
         self.assertFalse(os.path.exists(self.snap_device))
 
-        snapdev = elastio_snap.info(self.minor)
-        self.assertIsNotNone(snapdev)
-
-        self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], elastio_snap.State.UNVERIFIED)
-        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
-        self.assertEqual(snapdev["bdev"], self.device)
-        self.assertEqual(snapdev["version"], 0)
-        self.assertEqual(snapdev["falloc_size"], 0)
-        self.assertEqual(snapdev["ignore_snap_errors"], True)
+        self.check_snap_info(0, elastio_snap.State.UNVERIFIED, True)
 
         # Mount and test that the non-existent cow file been handled
         util.mount(self.device, self.mount)
         self.addCleanup(util.unmount, self.device, self.mount)
 
-        snapdev = elastio_snap.info(self.minor)
-        self.assertIsNotNone(snapdev)
+        self.check_snap_info(-errno.ENOENT, elastio_snap.State.UNVERIFIED, True)
 
-        self.assertEqual(snapdev["error"], -errno.ENOENT)
-        self.assertEqual(snapdev["state"], elastio_snap.State.UNVERIFIED)
-        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
-        self.assertEqual(snapdev["bdev"], self.device)
-        self.assertEqual(snapdev["version"], 0)
-        self.assertEqual(snapdev["falloc_size"], 0)
-        self.assertEqual(snapdev["ignore_snap_errors"], True)
 
     def test_reload_verified_snapshot(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path, ignore_snap_errors=True), 0)
@@ -134,16 +100,7 @@ class TestReload(DeviceTestCase):
         self.addCleanup(elastio_snap.destroy, self.minor)
         self.assertFalse(os.path.exists(self.snap_device))
 
-        snapdev = elastio_snap.info(self.minor)
-        self.assertIsNotNone(snapdev)
-
-        self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], elastio_snap.State.UNVERIFIED | elastio_snap.State.SNAPSHOT)
-        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
-        self.assertEqual(snapdev["bdev"], self.device)
-        self.assertEqual(snapdev["version"], 0)
-        self.assertEqual(snapdev["falloc_size"], 0)
-        self.assertEqual(snapdev["ignore_snap_errors"], False)
+        self.check_snap_info(0, elastio_snap.State.UNVERIFIED | elastio_snap.State.SNAPSHOT, False)
 
         # Mount and test that snapshot is active
         util.mount(self.device, self.mount)
@@ -152,16 +109,8 @@ class TestReload(DeviceTestCase):
         self.assertTrue(os.path.exists(self.cow_full_path))
         self.assertTrue(os.path.exists(self.snap_device))
 
-        snapdev = elastio_snap.info(self.minor)
-        self.assertIsNotNone(snapdev)
+        self.check_snap_info(0, elastio_snap.State.ACTIVE | elastio_snap.State.SNAPSHOT, False, 1)
 
-        self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], elastio_snap.State.ACTIVE | elastio_snap.State.SNAPSHOT)
-        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
-        self.assertEqual(snapdev["bdev"], self.device)
-        self.assertEqual(snapdev["version"], 1)
-        self.assertNotEqual(snapdev["falloc_size"], 0)
-        self.assertEqual(snapdev["ignore_snap_errors"], False)
 
     def test_reload_verified_inc(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path, ignore_snap_errors=True), 0)
@@ -178,16 +127,7 @@ class TestReload(DeviceTestCase):
         self.addCleanup(elastio_snap.destroy, self.minor)
         self.assertFalse(os.path.exists(self.snap_device))
 
-        snapdev = elastio_snap.info(self.minor)
-        self.assertIsNotNone(snapdev)
-
-        self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], elastio_snap.State.UNVERIFIED)
-        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
-        self.assertEqual(snapdev["bdev"], self.device)
-        self.assertEqual(snapdev["version"], 0)
-        self.assertEqual(snapdev["falloc_size"], 0)
-        self.assertEqual(snapdev["ignore_snap_errors"], False)
+        self.check_snap_info(0, elastio_snap.State.UNVERIFIED, False)
 
         # Mount and test that snapshot is active
         util.mount(self.device, self.mount)
@@ -196,16 +136,23 @@ class TestReload(DeviceTestCase):
         self.assertTrue(os.path.exists(self.cow_full_path))
         self.assertFalse(os.path.exists(self.snap_device))
 
+        self.check_snap_info(0, elastio_snap.State.ACTIVE, False, 1)
+
+
+    def check_snap_info(self, error, state, ignore_snap_errors, version = 0):
         snapdev = elastio_snap.info(self.minor)
         self.assertIsNotNone(snapdev)
 
-        self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], elastio_snap.State.ACTIVE)
+        self.assertEqual(snapdev["error"], error)
+        self.assertEqual(snapdev["state"], state)
         self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
         self.assertEqual(snapdev["bdev"], self.device)
-        self.assertEqual(snapdev["version"], 1)
-        self.assertNotEqual(snapdev["falloc_size"], 0)
-        self.assertEqual(snapdev["ignore_snap_errors"], False)
+        self.assertEqual(snapdev["version"], version)
+        self.assertEqual(snapdev["ignore_snap_errors"], ignore_snap_errors)
+        if  state & elastio_snap.State.ACTIVE:
+            self.assertGreater(snapdev["falloc_size"], 0)
+        else:
+            self.assertEqual(snapdev["falloc_size"], 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 #
-# Copyright (C) 2019 Datto, Inc.
-# Additional contributions by Elastio Software, Inc are Copyright (C) 2020 Elastio Software Inc.
+# Copyright (C) 2022 Elastio Software Inc.
 #
 
 import errno
@@ -71,7 +70,7 @@ class TestReload(DeviceTestCase):
         self.assertEqual(snapdev["falloc_size"], 0)
         self.assertEqual(snapdev["ignore_snap_errors"], True)
 
-        # Mount and test that handled not exist cow file
+        # Mount and test that the non-existent cow file been handled
         util.mount(self.device, self.mount)
         self.addCleanup(util.unmount, self.device, self.mount)
 
@@ -106,7 +105,7 @@ class TestReload(DeviceTestCase):
         self.assertEqual(snapdev["falloc_size"], 0)
         self.assertEqual(snapdev["ignore_snap_errors"], True)
 
-        # Mount and test that handled not exist cow file
+        # Mount and test that the non-existent cow file been handled
         util.mount(self.device, self.mount)
         self.addCleanup(util.unmount, self.device, self.mount)
 

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -64,7 +64,7 @@ class TestReload(DeviceTestCase):
         self.assertIsNotNone(snapdev)
 
         self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], 5) #NOTE: UNVERIFIED | SNAPSHOT
+        self.assertEqual(snapdev["state"], elastio_snap.State.UNVERIFIED | elastio_snap.State.SNAPSHOT)
         self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
         self.assertEqual(snapdev["bdev"], self.device)
         self.assertEqual(snapdev["version"], 0)
@@ -79,7 +79,7 @@ class TestReload(DeviceTestCase):
         self.assertIsNotNone(snapdev)
 
         self.assertEqual(snapdev["error"], -errno.ENOENT)
-        self.assertEqual(snapdev["state"], 5) #NOTE: UNVERIFIED | SNAPSHOT
+        self.assertEqual(snapdev["state"], elastio_snap.State.UNVERIFIED | elastio_snap.State.SNAPSHOT)
         self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
         self.assertEqual(snapdev["bdev"], self.device)
         self.assertEqual(snapdev["version"], 0)
@@ -99,7 +99,7 @@ class TestReload(DeviceTestCase):
         self.assertIsNotNone(snapdev)
 
         self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], 4) #NOTE: UNVERIFIED
+        self.assertEqual(snapdev["state"], elastio_snap.State.UNVERIFIED)
         self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
         self.assertEqual(snapdev["bdev"], self.device)
         self.assertEqual(snapdev["version"], 0)
@@ -114,7 +114,7 @@ class TestReload(DeviceTestCase):
         self.assertIsNotNone(snapdev)
 
         self.assertEqual(snapdev["error"], -errno.ENOENT)
-        self.assertEqual(snapdev["state"], 4) #NOTE: UNVERIFIED
+        self.assertEqual(snapdev["state"], elastio_snap.State.UNVERIFIED)
         self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
         self.assertEqual(snapdev["bdev"], self.device)
         self.assertEqual(snapdev["version"], 0)
@@ -139,7 +139,7 @@ class TestReload(DeviceTestCase):
         self.assertIsNotNone(snapdev)
 
         self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], 5) #NOTE: UNVERIFIED | SNAPSHOT
+        self.assertEqual(snapdev["state"], elastio_snap.State.UNVERIFIED | elastio_snap.State.SNAPSHOT)
         self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
         self.assertEqual(snapdev["bdev"], self.device)
         self.assertEqual(snapdev["version"], 0)
@@ -157,7 +157,7 @@ class TestReload(DeviceTestCase):
         self.assertIsNotNone(snapdev)
 
         self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], 3) #NOTE: ACTIVE | SNAPSHOT
+        self.assertEqual(snapdev["state"], elastio_snap.State.ACTIVE | elastio_snap.State.SNAPSHOT)
         self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
         self.assertEqual(snapdev["bdev"], self.device)
         self.assertEqual(snapdev["version"], 1)
@@ -183,7 +183,7 @@ class TestReload(DeviceTestCase):
         self.assertIsNotNone(snapdev)
 
         self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], 4) #NOTE: UNVERIFIED
+        self.assertEqual(snapdev["state"], elastio_snap.State.UNVERIFIED)
         self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
         self.assertEqual(snapdev["bdev"], self.device)
         self.assertEqual(snapdev["version"], 0)
@@ -201,7 +201,7 @@ class TestReload(DeviceTestCase):
         self.assertIsNotNone(snapdev)
 
         self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], 2) #NOTE: ACTIVE
+        self.assertEqual(snapdev["state"], elastio_snap.State.ACTIVE)
         self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
         self.assertEqual(snapdev["bdev"], self.device)
         self.assertEqual(snapdev["version"], 1)

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-only
+
+#
+# Copyright (C) 2019 Datto, Inc.
+# Additional contributions by Elastio Software, Inc are Copyright (C) 2020 Elastio Software Inc.
+#
+
+import errno
+import os
+import unittest
+import platform
+import elastio_snap
+import util
+from devicetestcase import DeviceTestCase
+
+
+class TestReload(DeviceTestCase):
+    def setUp(self):
+        self.cow_file = "cow.snap"
+        self.cow_full_path = "{}/{}".format(self.mount, self.cow_file)
+        self.cow_reload_path = "/{}".format(self.cow_file)
+        self.snap_device = "/dev/elastio-snap{}".format(self.minor)
+
+    def test_reload_snap_invalid_minor(self):
+        self.assertEqual(elastio_snap.reload_snapshot(1000, self.device, self.cow_reload_path), errno.EINVAL)
+        self.assertFalse(os.path.exists(self.snap_device))
+        self.assertIsNone(elastio_snap.info(self.minor))
+
+    def test_reload_inc_invalid_minor(self):
+        self.assertEqual(elastio_snap.reload_incremental(1000, self.device, self.cow_reload_path), errno.EINVAL)
+        self.assertFalse(os.path.exists(self.snap_device))
+        self.assertIsNone(elastio_snap.info(self.minor))
+
+    def test_reload_snap_volume_path_is_dir(self):
+        self.assertEqual(elastio_snap.reload_snapshot(self.minor, self.mount, self.cow_full_path), errno.ENOTBLK)
+        self.assertFalse(os.path.exists(self.snap_device))
+        self.assertIsNone(elastio_snap.info(self.minor))
+
+    def test_reload_inc_volume_path_is_dir(self):
+        self.assertEqual(elastio_snap.reload_incremental(self.minor, self.mount, self.cow_full_path), errno.ENOTBLK)
+        self.assertFalse(os.path.exists(self.snap_device))
+        self.assertIsNone(elastio_snap.info(self.minor))
+
+    def test_reload_snap_device_no_exists(self):
+        self.assertEqual(elastio_snap.reload_snapshot(self.minor, "/dev/not_exist_device", self.cow_full_path), errno.ENOENT)
+        self.assertFalse(os.path.exists(self.snap_device))
+        self.assertIsNone(elastio_snap.info(self.minor))
+
+    def test_reload_inc_device_no_exists(self):
+        self.assertEqual(elastio_snap.reload_incremental(self.minor, "/dev/not_exist_device", self.cow_full_path), errno.ENOENT)
+        self.assertFalse(os.path.exists(self.snap_device))
+        self.assertIsNone(elastio_snap.info(self.minor))
+
+    def test_reload_unverified_snapshot(self):
+        util.unmount(self.mount)
+        self.addCleanup(util.mount, self.device, self.mount)
+
+        self.assertEqual(elastio_snap.reload_snapshot(self.minor, self.device, self.cow_reload_path, ignore_snap_errors=True), 0)
+        self.addCleanup(elastio_snap.destroy, self.minor)
+        self.assertFalse(os.path.exists(self.snap_device))
+
+        snapdev = elastio_snap.info(self.minor)
+        self.assertIsNotNone(snapdev)
+
+        self.assertEqual(snapdev["error"], 0)
+        self.assertEqual(snapdev["state"], 5) #NOTE: UNVERIFIED | SNAPSHOT
+        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
+        self.assertEqual(snapdev["bdev"], self.device)
+        self.assertEqual(snapdev["version"], 0)
+        self.assertEqual(snapdev["falloc_size"], 0)
+        self.assertEqual(snapdev["ignore_snap_errors"], True)
+
+        # Mount and test that handled not exist cow file
+        util.mount(self.device, self.mount)
+        self.addCleanup(util.unmount, self.device, self.mount)
+
+        snapdev = elastio_snap.info(self.minor)
+        self.assertIsNotNone(snapdev)
+
+        self.assertEqual(snapdev["error"], -errno.ENOENT)
+        self.assertEqual(snapdev["state"], 5) #NOTE: UNVERIFIED | SNAPSHOT
+        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
+        self.assertEqual(snapdev["bdev"], self.device)
+        self.assertEqual(snapdev["version"], 0)
+        self.assertEqual(snapdev["falloc_size"], 0)
+        self.assertEqual(snapdev["ignore_snap_errors"], True)
+
+
+    def test_reload_unverified_incremental(self):
+        util.unmount(self.mount)
+        self.addCleanup(util.mount, self.device, self.mount)
+
+        self.assertEqual(elastio_snap.reload_incremental(self.minor, self.device, self.cow_reload_path, ignore_snap_errors=True), 0)
+        self.addCleanup(elastio_snap.destroy, self.minor)
+        self.assertFalse(os.path.exists(self.snap_device))
+
+        snapdev = elastio_snap.info(self.minor)
+        self.assertIsNotNone(snapdev)
+
+        self.assertEqual(snapdev["error"], 0)
+        self.assertEqual(snapdev["state"], 4) #NOTE: UNVERIFIED
+        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
+        self.assertEqual(snapdev["bdev"], self.device)
+        self.assertEqual(snapdev["version"], 0)
+        self.assertEqual(snapdev["falloc_size"], 0)
+        self.assertEqual(snapdev["ignore_snap_errors"], True)
+
+        # Mount and test that handled not exist cow file
+        util.mount(self.device, self.mount)
+        self.addCleanup(util.unmount, self.device, self.mount)
+
+        snapdev = elastio_snap.info(self.minor)
+        self.assertIsNotNone(snapdev)
+
+        self.assertEqual(snapdev["error"], -errno.ENOENT)
+        self.assertEqual(snapdev["state"], 4) #NOTE: UNVERIFIED
+        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
+        self.assertEqual(snapdev["bdev"], self.device)
+        self.assertEqual(snapdev["version"], 0)
+        self.assertEqual(snapdev["falloc_size"], 0)
+        self.assertEqual(snapdev["ignore_snap_errors"], True)
+
+    def test_reload_verified_snapshot(self):
+        self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path, ignore_snap_errors=True), 0)
+
+        util.unmount(self.mount)
+        self.addCleanup(util.mount, self.device, self.mount)
+
+        self.kmod.unload()
+        self.kmod.load()
+        self.assertFalse(os.path.exists(self.snap_device))
+
+        self.assertEqual(elastio_snap.reload_snapshot(self.minor, self.device, self.cow_reload_path), 0)
+        self.addCleanup(elastio_snap.destroy, self.minor)
+        self.assertFalse(os.path.exists(self.snap_device))
+
+        snapdev = elastio_snap.info(self.minor)
+        self.assertIsNotNone(snapdev)
+
+        self.assertEqual(snapdev["error"], 0)
+        self.assertEqual(snapdev["state"], 5) #NOTE: UNVERIFIED | SNAPSHOT
+        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
+        self.assertEqual(snapdev["bdev"], self.device)
+        self.assertEqual(snapdev["version"], 0)
+        self.assertEqual(snapdev["falloc_size"], 0)
+        self.assertEqual(snapdev["ignore_snap_errors"], False)
+
+        # Mount and test that snapshot is active
+        util.mount(self.device, self.mount)
+        self.addCleanup(util.unmount, self.device, self.mount)
+
+        self.assertTrue(os.path.exists(self.cow_full_path))
+        self.assertTrue(os.path.exists(self.snap_device))
+
+        snapdev = elastio_snap.info(self.minor)
+        self.assertIsNotNone(snapdev)
+
+        self.assertEqual(snapdev["error"], 0)
+        self.assertEqual(snapdev["state"], 3) #NOTE: ACTIVE | SNAPSHOT
+        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
+        self.assertEqual(snapdev["bdev"], self.device)
+        self.assertEqual(snapdev["version"], 1)
+        self.assertNotEqual(snapdev["falloc_size"], 0)
+        self.assertEqual(snapdev["ignore_snap_errors"], False)
+
+    def test_reload_verified_inc(self):
+        self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path, ignore_snap_errors=True), 0)
+        self.assertEqual(elastio_snap.transition_to_incremental(self.minor), 0)
+
+        util.unmount(self.mount)
+        self.addCleanup(util.mount, self.device, self.mount)
+
+        self.kmod.unload()
+        self.kmod.load()
+        self.assertFalse(os.path.exists(self.snap_device))
+
+        self.assertEqual(elastio_snap.reload_incremental(self.minor, self.device, self.cow_reload_path), 0)
+        self.addCleanup(elastio_snap.destroy, self.minor)
+        self.assertFalse(os.path.exists(self.snap_device))
+
+        snapdev = elastio_snap.info(self.minor)
+        self.assertIsNotNone(snapdev)
+
+        self.assertEqual(snapdev["error"], 0)
+        self.assertEqual(snapdev["state"], 4) #NOTE: UNVERIFIED
+        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
+        self.assertEqual(snapdev["bdev"], self.device)
+        self.assertEqual(snapdev["version"], 0)
+        self.assertEqual(snapdev["falloc_size"], 0)
+        self.assertEqual(snapdev["ignore_snap_errors"], False)
+
+        # Mount and test that snapshot is active
+        util.mount(self.device, self.mount)
+        self.addCleanup(util.unmount, self.device, self.mount)
+
+        self.assertTrue(os.path.exists(self.cow_full_path))
+        self.assertFalse(os.path.exists(self.snap_device))
+
+        snapdev = elastio_snap.info(self.minor)
+        self.assertIsNotNone(snapdev)
+
+        self.assertEqual(snapdev["error"], 0)
+        self.assertEqual(snapdev["state"], 2) #NOTE: ACTIVE
+        self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
+        self.assertEqual(snapdev["bdev"], self.device)
+        self.assertEqual(snapdev["version"], 1)
+        self.assertNotEqual(snapdev["falloc_size"], 0)
+        self.assertEqual(snapdev["ignore_snap_errors"], False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -86,7 +86,7 @@ class TestReload(DeviceTestCase):
         self.check_snap_info(-errno.ENOENT, elastio_snap.State.UNVERIFIED, True)
 
 
-    @unittest.skipIf(os.getenv('TEST_FS') == "ext2" and int(platform.release().split(".", 1)[0]) < 4, "Broken on ext2, 3-rd kernels")
+    @unittest.skipIf(int(platform.release().split(".", 1)[0]) < 4, "Broken on 3-rd kernels")
     def test_reload_verified_snapshot(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path, ignore_snap_errors=True), 0)
 

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -86,7 +86,7 @@ class TestReload(DeviceTestCase):
         self.check_snap_info(-errno.ENOENT, elastio_snap.State.UNVERIFIED, True)
 
 
-    @unittest.skipIf(int(platform.release().split(".", 1)[0]) < 4, "Broken on 3-rd kernels")
+    @unittest.skipIf(int(platform.release().split(".", 1)[0]) < 4, "Broken on 3-rd kernels. See https://github.com/elastio/elastio-snap/issues/202")
     def test_reload_verified_snapshot(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path, ignore_snap_errors=True), 0)
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -71,7 +71,7 @@ class TestSetup(DeviceTestCase):
         self.assertIsNotNone(snapdev)
 
         self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], 3)
+        self.assertEqual(snapdev["state"], elastio_snap.State.ACTIVE | elastio_snap.State.SNAPSHOT)
         self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
         self.assertEqual(snapdev["bdev"], self.device)
         self.assertEqual(snapdev["version"], 1)
@@ -100,7 +100,7 @@ class TestSetup(DeviceTestCase):
         self.assertIsNotNone(snapdev)
 
         self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], 3)
+        self.assertEqual(snapdev["state"], elastio_snap.State.ACTIVE | elastio_snap.State.SNAPSHOT)
         self.assertEqual(snapdev["cow"], "/{}".format(cow_file))
         self.assertEqual(snapdev["bdev"], device)
         self.assertEqual(snapdev["version"], 1)
@@ -117,7 +117,7 @@ class TestSetup(DeviceTestCase):
         self.assertIsNotNone(snapdev)
 
         self.assertEqual(snapdev["error"], 0)
-        self.assertEqual(snapdev["state"], 3)
+        self.assertEqual(snapdev["state"], elastio_snap.State.ACTIVE | elastio_snap.State.SNAPSHOT)
         self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
         self.assertEqual(snapdev["bdev"], self.device)
         self.assertEqual(snapdev["version"], 1)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -75,6 +75,7 @@ class TestSetup(DeviceTestCase):
         self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
         self.assertEqual(snapdev["bdev"], self.device)
         self.assertEqual(snapdev["version"], 1)
+        self.assertEqual(snapdev["ignore_snap_errors"], False)
 
     def test_setup_2_volumes(self):
         # Setup device #1 at the root volume
@@ -103,9 +104,10 @@ class TestSetup(DeviceTestCase):
         self.assertEqual(snapdev["cow"], "/{}".format(cow_file))
         self.assertEqual(snapdev["bdev"], device)
         self.assertEqual(snapdev["version"], 1)
+        self.assertEqual(snapdev["ignore_snap_errors"], False)
 
         # Setup device number 2, as ususally on an external disk or on a loopback device
-        self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)
+        self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path, ignore_snap_errors=True), 0)
         self.addCleanup(elastio_snap.destroy, self.minor)
 
         # Check the 2nd snapshot device
@@ -119,6 +121,7 @@ class TestSetup(DeviceTestCase):
         self.assertEqual(snapdev["cow"], "/{}".format(self.cow_file))
         self.assertEqual(snapdev["bdev"], self.device)
         self.assertEqual(snapdev["version"], 1)
+        self.assertEqual(snapdev["ignore_snap_errors"], True)
 
         # Destroy 1st snapshot device
         self.assertEqual(elastio_snap.destroy(minor), 0)

--- a/tests/test_transition_incremental.py
+++ b/tests/test_transition_incremental.py
@@ -61,7 +61,7 @@ class TestTransitionToIncremental(DeviceTestCase):
         self.assertIsNotNone(snapdev)
 
         self.assertEqual(snapdev["error"], -errno.EFBIG)
-        self.assertEqual(snapdev["state"], 3)
+        self.assertEqual(snapdev["state"], elastio_snap.State.ACTIVE | elastio_snap.State.SNAPSHOT)
 
     def test_transition_mod_sync_cow_full(self):
         scratch = "{}/scratch".format(self.mount)
@@ -86,7 +86,7 @@ class TestTransitionToIncremental(DeviceTestCase):
         self.assertIsNotNone(snapdev)
 
         self.assertEqual(snapdev["error"], -errno.EFBIG)
-        self.assertEqual(snapdev["state"], 2)
+        self.assertEqual(snapdev["state"], elastio_snap.State.ACTIVE)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added an optional `-i` argument to `elioctl` to switch off IO errors
propagation on snapshot read when the snap is in the failed state.
The same arg has been added to the library functions to setup a snap and
transition to a snap.
As result, the entire error handling has been refactored a bit.
Got rid of `sd_memory_fail_code` and `sd_cow_fail_state` snapshot
struct members. The error managing with usage of three error states, two
mentioned plus `sd_fail_code` was superfluous. Moreover, in case of
the snap dev memory mapping, IO errors were not propagated just in case
of the 2 errors: mem is too low and COW file size exceeded. Now all
other possible errors should not kill userspace app with `SIGBUS` if it
reads the snap as a memory-mapped file.

Resolves #185 