### PR TITLE
When used redirected storage, it did not work.

### DIFF
--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -2829,7 +2829,7 @@ static int bio_needs_cow(struct bio *bio, struct snap_device *dev){
 	bio_iter_bvec_t bvec;
 
 	if (!test_bit(COW_ON_BDEV, &dev->sd_cow_state)) {
-		return 0;
+		return 1;
 	}
 
 #ifdef HAVE_ENUM_REQ_OPF


### PR DESCRIPTION
Steps for reproduce:
```
root@user-vm:/home/kgermanov# mount -l | grep sda
/dev/sda5 on / type ext4 (rw,relatime,errors=remount-ro)
root@user-vm:/home/kgermanov# mount -l | grep sdb
/dev/sdb1 on /home/kgermanov/work type ext4 (rw,relatime,errors=remount-ro)

root@user-vm:/home/kgermanov# elioctl setup-snapshot -c 10 -f 200 /dev/sda5 /home/kgermanov/work/.eliosnap/snap0 1
root@user-vm:/home/kgermanov# mount /dev/elastio-snap1 /tmp/fs -o ro
mount: /tmp/fs: cannot mount /dev/elastio-snap1 read-only.
root@user-vm:/home/kgermanov# dmesg | tail
[631779.274226] EXT4-fs (elastio-snap1): INFO: recovery required on readonly filesystem
[631779.274231] EXT4-fs (elastio-snap1): write access unavailable, cannot proceed (try mounting with noload)
[631779.274330] elastio-snap: mount returned: -30
root@user-vm:/home/kgermanov# cat /home/kgermanov/work/.eliosnap/snap0 | hexdump -C
00000000  a8 12 00 00 00 00 00 00  01 8b 00 00 00 00 00 00  |................|
00000010  00 00 80 0c 00 00 00 00  01 00 00 00 00 00 00 00  |................|
00000020  f7 a4 3f a9 2e 35 4e 5d  99 1e b1 ca 5f 31 70 33  |..?..5N]...._1p3|
00000030  01 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000040  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
0c800000
```

It is because line https://github.com/elastio/elastio-snap/blob/master/src/elastio-snap.c#L2826 disable tracking:
```
static int bio_needs_cow(struct bio *bio, struct snap_device *dev){
	bio_iter_t iter;
	bio_iter_bvec_t bvec;

	if (!test_bit(COW_ON_BDEV, &dev->sd_cow_state)) {
		return 0; ///!!!
	}

	//check the inode of each page return true if it does not match our cow file
	bio_for_each_segment(bvec, bio, iter){
		if(page_get_inode(bio_iter_page(bio, iter)) != dev->sd_cow_inode) return 1;
	}
..............................
static int snap_trace_bio(struct snap_device *dev, struct bio *bio){
.......................
	//if we don't need to cow or physical memory usage has exceeded threshold or
	//	COW file state is failed, this bio just call the real mrf normally
	if (!bio_needs_cow(bio, dev) || memory_is_too_low(dev) || tracer_read_cow_fail_state(dev)) {
		return elastio_snap_call_mrf(dev->sd_orig_mrf, bio);
	}
```
We should simply skip check for inode and force trace this bio.