### PR TITLE
Add sytemd shutdown script for consistence rootfs

### DIFF
--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -6,6 +6,9 @@
 # Location to install kernel module sources
 %global _kmod_src_root %{_usrsrc}/%{name}-%{version}
 
+# Location for systemd shutdown script
+%global _systemd_shutdown /lib/systemd/system-shutdown
+
 # All sane distributions use dracut now, so here are dracut paths for it
 %if 0%{?rhel} > 0 && 0%{?rhel} < 7
 %global _dracut_modules_root %{_datadir}/dracut/modules.d
@@ -398,6 +401,10 @@ install -m 755 dist/initramfs/dracut/install %{buildroot}%{_dracut_modules_root}
 %endif
 %endif
 
+# Install systemd shutdown script
+mkdir -p %{buildroot}%{_systemd_shutdown}
+install -m 755 dist/system-shutdown/umount_rootfs.shutdown %{buildroot}%{_systemd_shutdown}/umount_rootfs.shutdown
+
 # Get rid of git artifacts
 find %{buildroot} -name "*.git*" -print0 | xargs -0 rm -rfv
 
@@ -514,6 +521,9 @@ rm -rf %{buildroot}
 %endif
 %endif
 %endif
+# Install systemd shutdown script
+%{_systemd_shutdown}/umount_rootfs.shutdown
+
 %doc README.md doc/STRUCTURE.md
 %if "%{_vendor}" == "redhat"
 %{!?_licensedir:%global license %doc}

--- a/dist/system-shutdown/umount_rootfs.shutdown
+++ b/dist/system-shutdown/umount_rootfs.shutdown
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+sync
+mount -o remount,ro /
+umount /


### PR DESCRIPTION
Testsed on Ubuntu 20.04. When reboot OS, than snapshots did not reload due initramfs:
![image](https://user-images.githubusercontent.com/59954122/209341526-a60087e0-a7f7-4700-b2dd-695fd405d054.png)
It was because it need to reapply journal and cannot do it in readonly mode. For avoid this we should remount rootfs to ro at the end of shutdown.

Fresh systems based on systemd and there is script, executed on shutdown.