### PR TITLE
Bump new version 0.12.1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ Elastio provides repositories for the following Linux distributions and architec
 | RHEL/CentOS/Alma Linux/Rocky Linux |         8-9 | +      | +       |
 | Amazon Linux                       |           2 | +      | +       |
 | Fedora                             |       31-34 | +      | -       |
-|                                    |       35-36 | +      | +       |
+|                                    |       35-37 | +      | +       |
 | Debian                             |         8-9 | +      | -       |
 |                                    |       10-11 | +      | +       |
 | Ubuntu                             | 16.04-18.04 | +      | -       |
@@ -108,7 +108,7 @@ These packages will install and configure the kernel module to start during the 
 
 ### Dependencies
 
-Note that this build process, while it _should_ work with any distribution, has only been tested with the distributions below. The lowest supported kernel is 3.10.
+Note that this build process, while it _should_ work with any distribution, has only been tested with the distributions below. The lowest supported kernel is 3.10.0.
 
 #### Debian/Ubuntu
 ```

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -109,7 +109,7 @@
 
 
 Name:            elastio-snap
-Version:         0.12.0
+Version:         0.12.1
 Release:         1%{?dist}
 Summary:         Kernel module and utilities for enabling low-level live backups
 Vendor:          Elastio Software, Inc.
@@ -609,6 +609,13 @@ rm -rf %{buildroot}
 
 
 %changelog
+
+* Wed Jan 4 2023 Stanislav Barantsev <sbarantsev@elastio.com> - 0.12.1
+- Fixed module compilation on Linux 6.0.14 for complete Fedora 37 support
+- Implemented 6.0.X Linux kernel support
+
+* Wed Dec 23 2022 Konstantin Germanov <kgermanov@axcient.com>
+- Added sytemd shutdown script for consistency of the rootfs in snapshots
 
 * Wed Dec 21 2022 Eugene Kovalenko <ikovalenko@elastio.com> - 0.12.0
 - Simplified error handling, got rid of sd_memory_fail_code and sd_cow_fail_state snapshot struct members

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -9,7 +9,7 @@
 #include "kernel-config.h"
 #include "elastio-snap.h"
 
-//current lowest supported kernel = 3.10
+//current lowest supported kernel = 3.10.0
 
 //basic information
 MODULE_LICENSE("GPL");

--- a/src/elastio-snap.h
+++ b/src/elastio-snap.h
@@ -16,7 +16,7 @@
 #include <linux/ioctl.h>
 #include <linux/limits.h>
 
-#define ELASTIO_SNAP_VERSION "0.12.0"
+#define ELASTIO_SNAP_VERSION "0.12.1"
 #define ELASTIO_IOCTL_MAGIC 'A' // 0x41
 
 struct setup_params{


### PR DESCRIPTION
It's a milestone after API change #187 and addition of the Linux kernel 6 and Fedora 37 support #204, #209.