### PR TITLE
[Internal/CI] Fix CI on Fedora when mirrors are down

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
               ;;
             esac
             for package in "kernel-core" "kernel-modules" "kernel" "kernel-devel"; do
-              sudo yum localinstall -y https://kojipkgs.fedoraproject.org/packages/kernel/${k_ver}/${k_patch}.fc${ver}/${arch}/${package}-${k_ver}-${k_patch}.fc${ver}.${arch}.rpm
+              sudo rpm -ivh --force https://kojipkgs.fedoraproject.org/packages/kernel/${k_ver}/${k_patch}.fc${ver}/${arch}/${package}-${k_ver}-${k_patch}.fc${ver}.${arch}.rpm
             done
             '
           vagrant reload ${{env.INSTANCE_NAME}}


### PR DESCRIPTION
Now `https://mirrors.fedoraproject.org/metalink?repo=fedora-35&arch=x86_64` returns 404 for Fedora 35. It may happen for any Fedora version time to time. The solution is not to use `yum/dnf` and use `rpm` to install kernel packages on CI. `rpm` does not fetch updates from all repos during the package installation.