### PR TITLE
Add retry logic on elastio_snap_destroy

### DIFF
--- a/tests/elastio_snap.py
+++ b/tests/elastio_snap.py
@@ -8,6 +8,7 @@
 from cffi import FFI
 import util
 import time
+import errno
 
 ffi = FFI()
 
@@ -104,16 +105,18 @@ def reload_incremental(minor, device, cow_file, cache_size=0, ignore_snap_errors
     return 0
 
 
-def destroy(minor, retries=3, debug=True):
+def destroy(minor, retries=3):
     for retry in range(retries):
         ret = lib.elastio_snap_destroy(minor)
         if ret == 0:
             util.settle()
             return 0
         else:
-            if debug == True:
+            if ffi.errno == errno.EBUSY:
                 print('Retry {} of {}: couldn\'t destroy device (minor {})'. format(retry + 1, retries, minor))
-            time.sleep(1)
+                time.sleep(1)
+            else:
+                break;
 
     return ffi.errno
 

--- a/tests/test_destroy.py
+++ b/tests/test_destroy.py
@@ -23,7 +23,7 @@ class TestDestroy(DeviceTestCase):
         self.snap_device = "/dev/elastio-snap{}".format(self.minor)
 
     def test_destroy_nonexistent_device(self):
-        self.assertEqual(elastio_snap.destroy(self.minor, retries=1, debug=False), errno.ENOENT)
+        self.assertEqual(elastio_snap.destroy(self.minor), errno.ENOENT)
 
     def test_destroy_active_snapshot(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)

--- a/tests/test_destroy.py
+++ b/tests/test_destroy.py
@@ -23,7 +23,7 @@ class TestDestroy(DeviceTestCase):
         self.snap_device = "/dev/elastio-snap{}".format(self.minor)
 
     def test_destroy_nonexistent_device(self):
-        self.assertEqual(elastio_snap.destroy(self.minor), errno.ENOENT)
+        self.assertEqual(elastio_snap.destroy(self.minor, retries=1, debug=False), errno.ENOENT)
 
     def test_destroy_active_snapshot(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -54,10 +54,10 @@ class TestReload(DeviceTestCase):
 
     def test_reload_unverified_snapshot(self):
         util.unmount(self.mount)
-        self.addCleanup(util.mount, self.device, self.mount)
 
         self.assertEqual(elastio_snap.reload_snapshot(self.minor, self.device, self.cow_reload_path, ignore_snap_errors=True), 0)
         self.addCleanup(elastio_snap.destroy, self.minor)
+        self.addCleanup(util.mount, self.device, self.mount)
         self.assertFalse(os.path.exists(self.snap_device))
 
         self.check_snap_info(0, elastio_snap.State.UNVERIFIED | elastio_snap.State.SNAPSHOT, True)
@@ -71,10 +71,10 @@ class TestReload(DeviceTestCase):
 
     def test_reload_unverified_incremental(self):
         util.unmount(self.mount)
-        self.addCleanup(util.mount, self.device, self.mount)
 
         self.assertEqual(elastio_snap.reload_incremental(self.minor, self.device, self.cow_reload_path, ignore_snap_errors=True), 0)
         self.addCleanup(elastio_snap.destroy, self.minor)
+        self.addCleanup(util.mount, self.device, self.mount)
         self.assertFalse(os.path.exists(self.snap_device))
 
         self.check_snap_info(0, elastio_snap.State.UNVERIFIED, True)
@@ -90,7 +90,6 @@ class TestReload(DeviceTestCase):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path, ignore_snap_errors=True), 0)
 
         util.unmount(self.mount)
-        self.addCleanup(util.mount, self.device, self.mount)
 
         self.kmod.unload()
         self.kmod.load(debug=1)
@@ -98,6 +97,7 @@ class TestReload(DeviceTestCase):
 
         self.assertEqual(elastio_snap.reload_snapshot(self.minor, self.device, self.cow_reload_path), 0)
         self.addCleanup(elastio_snap.destroy, self.minor)
+        self.addCleanup(util.mount, self.device, self.mount)
         self.assertFalse(os.path.exists(self.snap_device))
 
         self.check_snap_info(0, elastio_snap.State.UNVERIFIED | elastio_snap.State.SNAPSHOT, False)
@@ -117,7 +117,6 @@ class TestReload(DeviceTestCase):
         self.assertEqual(elastio_snap.transition_to_incremental(self.minor), 0)
 
         util.unmount(self.mount)
-        self.addCleanup(util.mount, self.device, self.mount)
 
         self.kmod.unload()
         self.kmod.load(debug=1)
@@ -125,6 +124,7 @@ class TestReload(DeviceTestCase):
 
         self.assertEqual(elastio_snap.reload_incremental(self.minor, self.device, self.cow_reload_path), 0)
         self.addCleanup(elastio_snap.destroy, self.minor)
+        self.addCleanup(util.mount, self.device, self.mount)
         self.assertFalse(os.path.exists(self.snap_device))
 
         self.check_snap_info(0, elastio_snap.State.UNVERIFIED, False)

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -54,6 +54,7 @@ class TestReload(DeviceTestCase):
 
     def test_reload_unverified_snapshot(self):
         util.unmount(self.mount)
+        self.addCleanup(util.mount, self.device, self.mount)
 
         self.assertEqual(elastio_snap.reload_snapshot(self.minor, self.device, self.cow_reload_path, ignore_snap_errors=True), 0)
         self.addCleanup(elastio_snap.destroy, self.minor)
@@ -63,12 +64,14 @@ class TestReload(DeviceTestCase):
 
         # Mount and test that the non-existent cow file been handled
         util.mount(self.device, self.mount)
+        self.addCleanup(util.unmount, self.device, self.mount)
 
         self.check_snap_info(-errno.ENOENT, elastio_snap.State.UNVERIFIED | elastio_snap.State.SNAPSHOT, True)
 
 
     def test_reload_unverified_incremental(self):
         util.unmount(self.mount)
+        self.addCleanup(util.mount, self.device, self.mount)
 
         self.assertEqual(elastio_snap.reload_incremental(self.minor, self.device, self.cow_reload_path, ignore_snap_errors=True), 0)
         self.addCleanup(elastio_snap.destroy, self.minor)
@@ -78,6 +81,7 @@ class TestReload(DeviceTestCase):
 
         # Mount and test that the non-existent cow file been handled
         util.mount(self.device, self.mount)
+        self.addCleanup(util.unmount, self.device, self.mount)
 
         self.check_snap_info(-errno.ENOENT, elastio_snap.State.UNVERIFIED, True)
 
@@ -86,6 +90,7 @@ class TestReload(DeviceTestCase):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path, ignore_snap_errors=True), 0)
 
         util.unmount(self.mount)
+        self.addCleanup(util.mount, self.device, self.mount)
 
         self.kmod.unload()
         self.kmod.load(debug=1)
@@ -99,6 +104,7 @@ class TestReload(DeviceTestCase):
 
         # Mount and test that snapshot is active
         util.mount(self.device, self.mount)
+        self.addCleanup(util.unmount, self.device, self.mount)
 
         self.assertTrue(os.path.exists(self.cow_full_path))
         self.assertTrue(os.path.exists(self.snap_device))
@@ -111,6 +117,7 @@ class TestReload(DeviceTestCase):
         self.assertEqual(elastio_snap.transition_to_incremental(self.minor), 0)
 
         util.unmount(self.mount)
+        self.addCleanup(util.mount, self.device, self.mount)
 
         self.kmod.unload()
         self.kmod.load(debug=1)
@@ -124,6 +131,7 @@ class TestReload(DeviceTestCase):
 
         # Mount and test that snapshot is active
         util.mount(self.device, self.mount)
+        self.addCleanup(util.unmount, self.device, self.mount)
 
         self.assertTrue(os.path.exists(self.cow_full_path))
         self.assertFalse(os.path.exists(self.snap_device))

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -54,7 +54,6 @@ class TestReload(DeviceTestCase):
 
     def test_reload_unverified_snapshot(self):
         util.unmount(self.mount)
-        self.addCleanup(util.mount, self.device, self.mount)
 
         self.assertEqual(elastio_snap.reload_snapshot(self.minor, self.device, self.cow_reload_path, ignore_snap_errors=True), 0)
         self.addCleanup(elastio_snap.destroy, self.minor)
@@ -64,14 +63,12 @@ class TestReload(DeviceTestCase):
 
         # Mount and test that the non-existent cow file been handled
         util.mount(self.device, self.mount)
-        self.addCleanup(util.unmount, self.device, self.mount)
 
         self.check_snap_info(-errno.ENOENT, elastio_snap.State.UNVERIFIED | elastio_snap.State.SNAPSHOT, True)
 
 
     def test_reload_unverified_incremental(self):
         util.unmount(self.mount)
-        self.addCleanup(util.mount, self.device, self.mount)
 
         self.assertEqual(elastio_snap.reload_incremental(self.minor, self.device, self.cow_reload_path, ignore_snap_errors=True), 0)
         self.addCleanup(elastio_snap.destroy, self.minor)
@@ -81,20 +78,17 @@ class TestReload(DeviceTestCase):
 
         # Mount and test that the non-existent cow file been handled
         util.mount(self.device, self.mount)
-        self.addCleanup(util.unmount, self.device, self.mount)
 
         self.check_snap_info(-errno.ENOENT, elastio_snap.State.UNVERIFIED, True)
 
 
-    @unittest.skipIf(int(platform.release().split(".", 1)[0]) < 4, "Broken on 3-rd kernels. See https://github.com/elastio/elastio-snap/issues/202")
     def test_reload_verified_snapshot(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path, ignore_snap_errors=True), 0)
 
         util.unmount(self.mount)
-        self.addCleanup(util.mount, self.device, self.mount)
 
         self.kmod.unload()
-        self.kmod.load()
+        self.kmod.load(debug=1)
         self.assertFalse(os.path.exists(self.snap_device))
 
         self.assertEqual(elastio_snap.reload_snapshot(self.minor, self.device, self.cow_reload_path), 0)
@@ -105,7 +99,6 @@ class TestReload(DeviceTestCase):
 
         # Mount and test that snapshot is active
         util.mount(self.device, self.mount)
-        self.addCleanup(util.unmount, self.device, self.mount)
 
         self.assertTrue(os.path.exists(self.cow_full_path))
         self.assertTrue(os.path.exists(self.snap_device))
@@ -118,10 +111,9 @@ class TestReload(DeviceTestCase):
         self.assertEqual(elastio_snap.transition_to_incremental(self.minor), 0)
 
         util.unmount(self.mount)
-        self.addCleanup(util.mount, self.device, self.mount)
 
         self.kmod.unload()
-        self.kmod.load()
+        self.kmod.load(debug=1)
         self.assertFalse(os.path.exists(self.snap_device))
 
         self.assertEqual(elastio_snap.reload_incremental(self.minor, self.device, self.cow_reload_path), 0)
@@ -132,7 +124,6 @@ class TestReload(DeviceTestCase):
 
         # Mount and test that snapshot is active
         util.mount(self.device, self.mount)
-        self.addCleanup(util.unmount, self.device, self.mount)
 
         self.assertTrue(os.path.exists(self.cow_full_path))
         self.assertFalse(os.path.exists(self.snap_device))


### PR DESCRIPTION
It was rarely seen on older kernels (f.e., Centos 7, v3.10) that sometimes the snapshot device cannot be instantaneously destroyed in the LVM configuration. It doesn't look like a serious driver issue with hidden consequences, so a simple retry functionality is suggested. Apart from that, the additional refactoring fixes were made for `test_reload.py` to make the tests more correct (removed unneded mount/umount cleanups).

Closes #202 