### PR TITLE
Fix issue with CoW file lock

### DIFF
--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -1825,7 +1825,6 @@ static int file_truncate(struct file *filp, loff_t len){
 #else
 	ret = vfs_truncate(&filp->f_path, len);
 #endif
-	file_lock(filp);
 
 	if(ret){
 		LOG_ERROR(ret, "error verifying truncation is possible");
@@ -1849,10 +1848,12 @@ static int file_truncate(struct file *filp, loff_t len){
 		goto error;
 	}
 
+	file_lock(filp);
 	return 0;
 
 error:
 	LOG_ERROR(ret, "error truncating file");
+	file_lock(filp);
 	return ret;
 }
 


### PR DESCRIPTION
The issue is related to these error messages noticed on PopOS (v6.0.12):

```
[  693.318921] elastio-snap: ioctl command received: 1074020613
[  693.318927] elastio-snap: received transition inc ioctl - 7
[  693.318929] elastio-snap: allocating device struct
[  693.318931] elastio-snap: initializing tracer
[  693.318933] elastio-snap: creating kernel cow thread
[  693.319053] elastio-snap: getting the base block device's make_request_fn
[  693.319055] elastio-snap: original mrf is already replaced with the tracing_mrf = 000000000f1649ea
[  693.319057] elastio-snap: found already traced device dm-5 with the same original bd_ops. orig mrf = 0000000007ac3a93; orig ops = 000000005947874e; tracing ops = 00000000f799ecd7
[  693.319059] elastio-snap: using already existing tracing ops for device with minor 7
[  693.319073] elastio-snap: freezing 'dm-5'
[  693.608738] elastio-snap: starting tracing
[  693.608751] elastio-snap: thawing 'dm-5'
[  693.644130] elastio-snap: stopping cow thread
[  693.644877] elastio-snap: error performing truncation: -1
[  693.644892] elastio-snap: error truncating file: -1
[  693.644906] elastio-snap: warning: failed to truncate '/tmp/elastio-snap_007/cow.snap', incremental will use more disk space than needed`
[  693.644911] elastio-snap: stopping mrf thread
[  693.644965] elastio-snap: freeing gendisk
[  693.681131] elastio-snap: freeing request queue
[  693.681591] elastio-snap: minor range = 7 - 7
```

It was also reproduced on Fedora 37 (v6.0.14).

The problem was caused by the usage of `file_unlock()` function in the incorrect place, which made the truncation impossible.

Closes #212 