### PR TITLE
Add build for AL2023 x86_64

### DIFF
--- a/.github/buildbox/Vagrantfile
+++ b/.github/buildbox/Vagrantfile
@@ -35,14 +35,14 @@ ENV_VARS_SCRIPT
 
 DISTRO = {}
 DISTRO['amd64'] = [ "debian8", "debian9", "debian10", "debian11",
-                    "amazon2",
+                    "amazon2", "amazon2023",
                     "centos7", "centos8", "centos9",
                     "alma8", "alma9",
                     "fedora31", "fedora32", "fedora34", "fedora35", "fedora36", "fedora37",
                     "ubuntu2004", "ubuntu2204" ]
 
 DISTRO['arm64'] = [ "debian10", "debian11",
-                    "amazon2",
+                    "amazon2", "amazon2023",
                     "centos8", "centos9",
                     "alma8", "alma9",
                     "fedora35", "fedora36", "fedora37",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         distro: [
-          amazon2,
+          amazon2, amazon2023,
           centos7, centos8, centos9,
           debian8, debian9, debian10, debian11,
           fedora31, fedora32, fedora34, fedora35, fedora36, fedora37,


### PR DESCRIPTION
Closes #239

I'd say it closes only `x86_64` half of the task.
But then I thought we'll have Fedora 38 with the 6.1 kernel soon. And for that we will have boxes with both architectures for sure.