### PR TITLE
Fix for the Linux Kernel v6.2 (Fedora 37/38)

### DIFF
--- a/.github/buildbox/Vagrantfile
+++ b/.github/buildbox/Vagrantfile
@@ -38,14 +38,14 @@ DISTRO['amd64'] = [ "debian8", "debian9", "debian10", "debian11",
                     "amazon2", "amazon2023",
                     "centos7", "centos8", "centos9",
                     "alma8", "alma9",
-                    "fedora31", "fedora32", "fedora34", "fedora35", "fedora36", "fedora37",
+                    "fedora31", "fedora32", "fedora34", "fedora35", "fedora36", "fedora37", "fedora38",
                     "ubuntu2004", "ubuntu2204" ]
 
 DISTRO['arm64'] = [ "debian10", "debian11",
                     "amazon2", "amazon2023",
                     "centos8", "centos9",
                     "alma8", "alma9",
-                    "fedora35", "fedora36", "fedora37",
+                    "fedora35", "fedora36", "fedora37", "fedora38",
                     "ubuntu2204" ]
 
 # NOTE: This environment variable should be set to enable triggers of the type "action".

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           amazon2, amazon2023,
           centos7, centos8, centos9,
           debian8, debian9, debian10, debian11,
-          fedora31, fedora32, fedora34, fedora35, fedora36, fedora37,
+          fedora31, fedora32, fedora34, fedora35, fedora36, fedora37, fedora38,
           ubuntu2004, ubuntu2204
         ]
         arch: [ amd64 ]
@@ -53,6 +53,8 @@ jobs:
           - distro: fedora36
             arch: arm64
           - distro: fedora37
+            arch: arm64
+          - distro: fedora38
             arch: arm64
           - distro: ubuntu2204
             arch: arm64

--- a/src/configure-tests/feature-tests/bio_set_op_attrs.c
+++ b/src/configure-tests/feature-tests/bio_set_op_attrs.c
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2023 Elastio Software Inc.
+ */
+
+// kernel_version < 6.2
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct bio bio;
+
+	bio_set_op_attrs(&bio, REQ_OP_READ, 0);
+}

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -296,8 +296,12 @@ typedef enum req_opf req_op_t;
 #endif
 
 static inline void elastio_snap_set_bio_ops(struct bio *bio, req_op_t op, unsigned op_flags){
+#ifdef HAVE_BIO_SET_OP_ATTRS
 	bio->bi_opf = 0;
 	bio_set_op_attrs(bio, op, op_flags);
+#else
+	bio->bi_opf = op | op_flags;
+#endif
 }
 
 static inline int elastio_snap_bio_op_flagged(struct bio *bio, unsigned int flag){
@@ -2834,6 +2838,7 @@ static inline struct inode *page_get_inode(struct page *pg){
 #endif
 	if(PageAnon(pg)) return NULL;
 	if(!pg->mapping) return NULL;
+	if (!virt_addr_valid(pg->mapping)) return NULL;
 	return pg->mapping->host;
 }
 

--- a/tests/devicetestcase.py
+++ b/tests/devicetestcase.py
@@ -41,7 +41,7 @@ class DeviceTestCase(unittest.TestCase):
                     if not r in seeds: break
                 seeds.append(r)
                 cls.backing_stores.append("/tmp/disk_{0:03d}.img".format(seeds[i]))
-                util.dd("/dev/zero", cls.backing_stores[i], 256, bs="1M")
+                util.dd("/dev/zero", cls.backing_stores[i], 512, bs="1M")
                 cls.devices.append(util.loop_create(cls.backing_stores[i]))
 
         if len(cls.devices) == 1:

--- a/tests/devicetestcase_multipart.py
+++ b/tests/devicetestcase_multipart.py
@@ -41,7 +41,7 @@ class DeviceTestCaseMultipart(unittest.TestCase):
             util.partition(cls.device, cls.part_count)
         else:
             cls.backing_store = ("/tmp/disk_{0:03d}.img".format(cls.minors[0]))
-            util.dd("/dev/zero", cls.backing_store, 256, bs="1M")
+            util.dd("/dev/zero", cls.backing_store, 2560, bs="1M")
             cls.device = util.loop_create(cls.backing_store, cls.part_count)
 
         cls.devices = []


### PR DESCRIPTION
* Enable Fedora 38
* Added compat for `bio_set_op_attrs`
* Fixed kernel panic on dereferencing the wrong address

Closes #247 