### PR TITLE
Create cow file precisely according to the user setting

### DIFF
--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -2845,6 +2845,7 @@ static int cow_init(struct snap_device *dev, const char *path, uint64_t elements
 	cm->nr_changed_blocks = 0;
 	cm->flags = 0;
 	cm->allocated_sects = 0;
+	cm->file_max = file_max;
 	cm->sect_size = sect_size;
 	cm->seqid = seqid;
 
@@ -3010,25 +3011,23 @@ static int __cow_write_data(struct cow_manager *cm, void *buf){
 	int ret;
 	char *abs_path = NULL;
 	int abs_path_len;
-	uint64_t data_offset = COW_HEADER_SIZE + (cm->total_sects * (COW_SECTION_SIZE * sizeof(uint64_t)));
-	uint64_t curr_offset = cm->curr_pos * COW_BLOCK_SIZE;
-	uint64_t max_offset = cm->file_max - data_offset;
+	uint64_t curr_size = cm->curr_pos * COW_BLOCK_SIZE;
 
-	if(curr_offset >= cm->file_max - data_offset) {
+	if(curr_size >= cm->file_max) {
 		ret = -EFBIG;
 
 		file_get_absolute_pathname(cm->filp, &abs_path, &abs_path_len);
 		if(!abs_path){
-			LOG_ERROR(ret, "cow file max size exceeded (%llu/%llu)", curr_offset, max_offset);
+			LOG_ERROR(ret, "cow file max size exceeded (%llu/%llu)", curr_size, cm->file_max);
 		}else{
-			LOG_ERROR(ret, "cow file '%s' max size exceeded (%llu/%llu)", abs_path, curr_offset, max_offset);
+			LOG_ERROR(ret, "cow file '%s' max size exceeded (%llu/%llu)", abs_path, curr_size, cm->file_max);
 			kfree(abs_path);
 		}
 
 		goto error;
 	}
 
-	ret = file_write(cm, buf, curr_offset, COW_BLOCK_SIZE);
+	ret = file_write(cm, buf, curr_size, COW_BLOCK_SIZE);
 	if(ret) goto error;
 
 	cm->curr_pos++;
@@ -4626,6 +4625,8 @@ static int __tracer_setup_cow(struct snap_device *dev, struct block_device *bdev
 			if(!fallocated_space){
 				max_file_size = size * SECTOR_SIZE * elastio_snap_cow_fallocate_percentage_default;
 				do_div(max_file_size, 100);
+				dev->sd_falloc_size = max_file_size;
+				do_div(dev->sd_falloc_size, (1024 * 1024));
 			}else{
 				max_file_size = fallocated_space * (1024 * 1024);
 			}
@@ -4634,10 +4635,6 @@ static int __tracer_setup_cow(struct snap_device *dev, struct block_device *bdev
 			LOG_DEBUG("creating cow manager");
 			ret = cow_init(dev, cow_path_full, SECTOR_TO_BLOCK(size), COW_SECTION_SIZE, dev->sd_cache_size, max_file_size, uuid, seqid, &dev->sd_cow);
 			if(ret) goto error;
-
-			dev->sd_falloc_size = dev->sd_cow->file_max;
-			do_div(dev->sd_falloc_size, (1024 * 1024));
-
 		}else{
 			//reload the cow manager
 			LOG_DEBUG("reloading cow manager");

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -2187,6 +2187,7 @@ static int file_allocate(struct cow_manager *cm, struct file *f, uint64_t offset
 
 	//may write up to a page too much, ok for our use case
 	write_count = NUM_SEGMENTS(length, PAGE_SHIFT);
+	LOG_DEBUG("allocating cow file (%llu bytes)", PAGE_SIZE * write_count);
 
 	//if not page aligned, write zeros to that point
 	if(offset % PAGE_SIZE != 0){
@@ -2883,7 +2884,6 @@ static int cow_init(struct snap_device *dev, const char *path, uint64_t elements
 	cm->allowed_sects = __cow_calculate_allowed_sects(cache_size, cm->total_sects);
 	cm->data_offset = COW_HEADER_SIZE + (cm->total_sects * (sect_size * sizeof(uint64_t)));
 	cm->curr_pos = cm->data_offset / COW_BLOCK_SIZE;
-	cm->file_max = file_max + cm->data_offset; // reserve additional room for sections
 	cm->dev = dev;
 
 	if(uuid) memcpy(cm->uuid, uuid, COW_UUID_SIZE);
@@ -2902,7 +2902,6 @@ static int cow_init(struct snap_device *dev, const char *path, uint64_t elements
 		}
 	}
 
-	LOG_DEBUG("allocating cow file (%llu bytes)", (unsigned long long)file_max);
 	ret = file_allocate(cm, cm->filp, 0, file_max);
 	if(ret) goto error;
 

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -4625,11 +4625,13 @@ static int __tracer_setup_cow(struct snap_device *dev, struct block_device *bdev
 			if(!fallocated_space){
 				max_file_size = size * SECTOR_SIZE * elastio_snap_cow_fallocate_percentage_default;
 				do_div(max_file_size, 100);
-				dev->sd_falloc_size = max_file_size;
-				do_div(dev->sd_falloc_size, (1024 * 1024));
+				max_file_size = ALIGN(max_file_size, PAGE_SIZE);
 			}else{
-				max_file_size = fallocated_space * (1024 * 1024);
+				max_file_size = ALIGN(fallocated_space * (1024 * 1024), PAGE_SIZE);
 			}
+
+			dev->sd_falloc_size = max_file_size;
+			do_div(dev->sd_falloc_size, (1024 * 1024));
 
 			//create and open the cow manager
 			LOG_DEBUG("creating cow manager");

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -73,9 +73,10 @@ class TestSetup(DeviceTestCase):
 
         page_size = util.os_page_size()
         cow_file_size_factor = 0.1 # 10% by default if `fallocated_space` is 0
-        cow_size_bytes = util.dev_size_mb(self.device) * 1024 * 1024 * cow_file_size_factor
-        cow_file_size = (int)(round(cow_size_bytes / page_size) * page_size);
+        cow_file_size = util.dev_size_mb(self.device) * 1024 * 1024 * cow_file_size_factor
 
+        # rounding up aligned to the PAGE_SIZE
+        cow_file_size = int(math.ceil(cow_file_size / page_size) * page_size);
         self.assertEqual(os.stat(self.cow_full_path).st_size, cow_file_size)
 
     def test_setup_check_cow_size_fallocate(self):
@@ -83,9 +84,10 @@ class TestSetup(DeviceTestCase):
         self.addCleanup(elastio_snap.destroy, self.minor)
 
         page_size = util.os_page_size()
-        cow_size_bytes = 50 * 1024 * 1024
-        cow_file_size = (int)(round(cow_size_bytes / page_size) * page_size);
+        cow_file_size = 50 * 1024 * 1024
 
+        # rounding up aligned to the PAGE_SIZE
+        cow_file_size = int(math.ceil(cow_file_size / page_size) * page_size);
         self.assertEqual(os.stat(self.cow_full_path).st_size, cow_file_size)
 
     def test_setup_volume(self):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -79,6 +79,9 @@ class TestSetup(DeviceTestCase):
         cow_file_size = int(math.ceil(cow_file_size / page_size) * page_size);
         self.assertEqual(os.stat(self.cow_full_path).st_size, cow_file_size)
 
+        snapdev = elastio_snap.info(self.minor)
+        self.assertEqual(snapdev["falloc_size"], cow_file_size)
+
     def test_setup_check_cow_size_fallocate(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path, fallocated_space=50), 0)
         self.addCleanup(elastio_snap.destroy, self.minor)
@@ -89,6 +92,9 @@ class TestSetup(DeviceTestCase):
         # rounding up aligned to the PAGE_SIZE
         cow_file_size = int(math.ceil(cow_file_size / page_size) * page_size);
         self.assertEqual(os.stat(self.cow_full_path).st_size, cow_file_size)
+
+        snapdev = elastio_snap.info(self.minor)
+        self.assertEqual(snapdev["falloc_size"], cow_file_size)
 
     def test_setup_volume(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -73,7 +73,7 @@ class TestSetup(DeviceTestCase):
 
         page_size = util.os_page_size()
         cow_file_size_factor = 0.1 # 10% by default if `fallocated_space` is 0
-        cow_file_size = util.dev_size_mb(self.device) * 1024 * 1024 * cow_file_size_factor
+        cow_file_size = util.dev_size_bytes(self.device) * cow_file_size_factor
 
         # rounding up aligned to the PAGE_SIZE
         cow_file_size = int(math.ceil(cow_file_size / page_size) * page_size);

--- a/tests/util.py
+++ b/tests/util.py
@@ -307,3 +307,7 @@ def test_track(test_name, started):
             f.write('<6>--- {} started ---'.format(test_name))
         else:
             f.write('<6>--- {} done. ---'.format(test_name))
+
+def os_page_size():
+    cmd = ["getconf", "PAGESIZE"]
+    return (int)(subprocess.check_output(cmd, timeout=10).rstrip().decode("utf-8"))

--- a/tests/util.py
+++ b/tests/util.py
@@ -126,6 +126,8 @@ def mkfs(device, fs="ext4"):
 def dev_size_mb(device):
     return int(subprocess.check_output("blockdev --getsize64 %s" % device, shell=True))//1024**2
 
+def dev_size_bytes(device):
+    return int(subprocess.check_output("blockdev --getsize64 %s" % device, shell=True))
 
 # This method finds names of the partitions of the disk
 def get_partitions(disk):


### PR DESCRIPTION
Currently, the size of the COW file is the sum of the header size, mapping section, and the snapshot data itself.
This was added on purpose in one of the previous tasks and caused some issues with other tests. This approach
implicitly adds some additional size to the `fallocate` specified by the user. It is now agreed that for the system
administrators, it is more critical to precisely control the used disk space used, so we will bring the initial behavior
back. This means, that if the user specifies 10% of the disk for the COW file, this should be the precise size of the
COW file and no additional data should be added to it.

Changes:
 * Brought back the previous logic of the COW file size calculation
 * Added two CI tests that compare the expected and real COW file sizes

Closes #253 