### PR TITLE
Fix for the Linux Kernel v6.2 (Fedora 37/38)

### DIFF
--- a/.github/buildbox/Vagrantfile
+++ b/.github/buildbox/Vagrantfile
@@ -38,14 +38,14 @@ DISTRO['amd64'] = [ "debian8", "debian9", "debian10", "debian11",
                     "amazon2", "amazon2023",
                     "centos7", "centos8", "centos9",
                     "alma8", "alma9",
-                    "fedora31", "fedora32", "fedora34", "fedora35", "fedora36", "fedora37",
+                    "fedora31", "fedora32", "fedora34", "fedora35", "fedora36", "fedora37", "fedora38",
                     "ubuntu2004", "ubuntu2204" ]
 
 DISTRO['arm64'] = [ "debian10", "debian11",
                     "amazon2", "amazon2023",
                     "centos8", "centos9",
                     "alma8", "alma9",
-                    "fedora35", "fedora36", "fedora37",
+                    "fedora35", "fedora36", "fedora37", "fedora38",
                     "ubuntu2204" ]
 
 # NOTE: This environment variable should be set to enable triggers of the type "action".

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           amazon2, amazon2023,
           centos7, centos8, centos9,
           debian8, debian9, debian10, debian11,
-          fedora31, fedora32, fedora34, fedora35, fedora36, fedora37,
+          fedora31, fedora32, fedora34, fedora35, fedora36, fedora37, fedora38,
           ubuntu2004, ubuntu2204
         ]
         arch: [ amd64 ]
@@ -53,6 +53,8 @@ jobs:
           - distro: fedora36
             arch: arm64
           - distro: fedora37
+            arch: arm64
+          - distro: fedora38
             arch: arm64
           - distro: ubuntu2204
             arch: arm64
@@ -232,10 +234,10 @@ jobs:
 
       - name: Attach qcow2 disks
         run: |
+          SZ="2G"
           ARCH=$(uname -m)
           TEST_IMAGES=(${TEST_IMAGES})
           TEST_DRIVES=(${TEST_DRIVES})
-          [ ${ARCH} == "x86_64" ] && SZ="1G" || SZ="256M"
           [ ${ARCH} != "x86_64" ] && VIRSH_FLAGS="--config" || true
           for i in ${!TEST_IMAGES[*]}; do
             qemu-img create -f qcow2 ${TEST_IMAGES[i]} $SZ

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
 
       - name: Attach qcow2 disks
         run: |
-          SZ="2G"
+          SZ="1G"
           ARCH=$(uname -m)
           TEST_IMAGES=(${TEST_IMAGES})
           TEST_DRIVES=(${TEST_DRIVES})

--- a/src/configure-tests/feature-tests/bio_set_op_attrs.c
+++ b/src/configure-tests/feature-tests/bio_set_op_attrs.c
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2023 Elastio Software Inc.
+ */
+
+// kernel_version < 6.2
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct bio bio;
+
+	bio_set_op_attrs(&bio, REQ_OP_READ, 0);
+}

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -298,8 +298,12 @@ typedef enum req_opf req_op_t;
 #endif
 
 static inline void elastio_snap_set_bio_ops(struct bio *bio, req_op_t op, unsigned op_flags){
+#ifdef HAVE_BIO_SET_OP_ATTRS
 	bio->bi_opf = 0;
 	bio_set_op_attrs(bio, op, op_flags);
+#else
+	bio->bi_opf = op | op_flags;
+#endif
 }
 
 static inline int elastio_snap_bio_op_flagged(struct bio *bio, unsigned int flag){
@@ -3341,6 +3345,7 @@ static inline struct inode *page_get_inode(struct page *pg){
 #endif
 	if(PageAnon(pg)) return NULL;
 	if(!pg->mapping) return NULL;
+	if (!virt_addr_valid(pg->mapping)) return NULL;
 	return pg->mapping->host;
 }
 

--- a/tests/devicetestcase.py
+++ b/tests/devicetestcase.py
@@ -22,7 +22,7 @@ class DeviceTestCase(unittest.TestCase):
         seeds = []
         cls.backing_stores = []
         cls.devices = []
-        cls.size_mb = 256
+        cls.size_mb = 512
         cls.is_raid = False
 
         cls.kmod = kmod.Module("../src/elastio-snap.ko")

--- a/tests/devicetestcase_multipart.py
+++ b/tests/devicetestcase_multipart.py
@@ -25,7 +25,7 @@ class DeviceTestCaseMultipart(unittest.TestCase):
 
         # We create the device big enough to perform
         # representative 'test_multipart_modify_origins'
-        cls.size_mb = 1024
+        cls.size_mb = 2560
 
         for i in range(cls.part_count):
             # Unexpectedly randint can generate 2 same numbers in a row.

--- a/tests/devicetestcase_multipart.py
+++ b/tests/devicetestcase_multipart.py
@@ -19,13 +19,12 @@ from random import randint
 class DeviceTestCaseMultipart(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        # For now let's hardcode 7 partitions
-        cls.part_count = 7
+        cls.part_count = 3
         cls.minors = []
 
         # We create the device big enough to perform
         # representative 'test_multipart_modify_origins'
-        cls.size_mb = 2560
+        cls.size_mb = 1024
 
         for i in range(cls.part_count):
             # Unexpectedly randint can generate 2 same numbers in a row.

--- a/tests/util.py
+++ b/tests/util.py
@@ -24,7 +24,7 @@ def unmount(path, retry_on_dev_busy=True):
     cmd = ["umount", path]
     # subprocess.run is introduced in Python 3.5
     if not retry_on_dev_busy or sys.version_info <= (3, 5):
-        subprocess.check_call(cmd, timeout=10)
+        subprocess.check_call(cmd, timeout=20)
     else:
         # The retries on device busy error are necessary on Ubuntu 22.04, kernel 5.15
         # for the tests test_destroy_unverified_incremental and test_destroy_unverified_snapshot.


### PR DESCRIPTION
* Enable Fedora 38
* Added compat for bio_set_op_attrs
* Fixed kernel panic on dereferencing the wrong address
* Increased volume sizes for the new mkfs.xfs (needs at least 300 MB per partition)