### PR TITLE
Implement update-img for Centos8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
         timeout-minutes: 5
 
       - name: Build packages
-        run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'make ${PKG_TYPE}'
+        run: vagrant ssh ${{env.INSTANCE_NAME}} -c 'sudo make ${PKG_TYPE}'
         working-directory: ${{env.BOX_DIR}}
 
       - name: Collect artifacts

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,10 @@ pkgprep: pkgclean
 	tar --exclude=./pkgbuild --exclude=.git --transform 's,^\.,elastio-snap,' -czf $(BUILDDIR)/SOURCES/elastio-snap.tar.gz .
 	cp dist/elastio-snap.spec $(BUILDDIR)/SPECS/elastio-snap.spec
 
-deb: pkgprep
+deb: check_root pkgprep
 	debbuild $(PKGBUILDFLAGS) $(BUILDDIR)/SPECS/elastio-snap.spec
 
-rpm: pkgprep
+rpm: check_root pkgprep
 	rpmbuild $(PKGBUILDFLAGS) $(BUILDDIR)/SPECS/elastio-snap.spec
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ endif
 driver: check_root
 	$(MAKE) -C src
 
-library-shared:
+library-shared: driver
 	$(MAKE) -C lib CCFLAGS="$(CCFLAGS) -I$(BASE_DIR)/src" shared
 
-library-static:
+library-static: driver
 	$(MAKE) -C lib CCFLAGS="$(CCFLAGS) -I$(BASE_DIR)/src" static
 
 library: library-shared library-static

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ driver: check_root
 	$(MAKE) -C src
 
 $(KERNEL_CONFIG):
-	./src/genconfig.sh "$(shell uname -r)"
+	$(BASE_DIR)/src/genconfig.sh "$(shell uname -r)"
 
 library-shared: $(KERNEL_CONFIG)
 	$(MAKE) -C lib CCFLAGS="$(CCFLAGS) -I$(BASE_DIR)/src" shared

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -580,6 +580,7 @@ rm -rf %{buildroot}
 %if 0%{?rhel} == 5 && 0%{?rhel} == 6 && 0%{?suse_version} == 1110
 # RHEL/CentOS 5/6 and SLE 11 don't support this at all
 %exclude %{_sysconfdir}/modules-load.d/elastio-snap.conf
+%exclude %{_kmod_src_root}/configure-tests/feature-tests/build
 %else
 %config %{_sysconfdir}/modules-load.d/elastio-snap.conf
 %endif

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -580,7 +580,6 @@ rm -rf %{buildroot}
 %if 0%{?rhel} == 5 && 0%{?rhel} == 6 && 0%{?suse_version} == 1110
 # RHEL/CentOS 5/6 and SLE 11 don't support this at all
 %exclude %{_sysconfdir}/modules-load.d/elastio-snap.conf
-%exclude %{_kmod_src_root}/configure-tests/feature-tests/build
 %else
 %config %{_sysconfdir}/modules-load.d/elastio-snap.conf
 %endif
@@ -595,6 +594,7 @@ rm -rf %{buildroot}
 %{_kmod_src_root}/dkms.conf
 %{_kmod_src_root}/genconfig.sh
 %{_kmod_src_root}/includes.h
+%exclude %dir %{_kmod_src_root}/configure-tests/feature-tests/build
 %if 0%{?rhel} == 5 || (0%{?suse_version} && 0%{?suse_version} < 1315) || (0%{?fedora} && 0%{?fedora} < 23)
 %dir %{_sysconfdir}/kernel/postinst.d
 %{_sysconfdir}/kernel/postinst.d/50-elastio-snap

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -312,6 +312,7 @@ automatically build and install for each kernel.
 export CFLAGS="%{optflags}"
 make application
 make utils
+rm -rf src/kernel-config.h
 
 
 %install

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -312,7 +312,9 @@ automatically build and install for each kernel.
 export CFLAGS="%{optflags}"
 make application
 make utils
-rm -rf src/kernel-config.h
+# Not needs to be installed: we expect the
+# user to generate it during the build
+rm -f src/kernel-config.h
 
 
 %install

--- a/lib/libelastio-snap.h
+++ b/lib/libelastio-snap.h
@@ -8,6 +8,7 @@
 #ifndef LIBELASTIO_SNAP_H_
 #define LIBELASTIO_SNAP_H_
 
+#include "kernel-config.h"
 #include "elastio-snap.h"
 #include <stdbool.h>
 

--- a/lib/libelastio-snap.h
+++ b/lib/libelastio-snap.h
@@ -8,7 +8,6 @@
 #ifndef LIBELASTIO_SNAP_H_
 #define LIBELASTIO_SNAP_H_
 
-#include "kernel-config.h"
 #include "elastio-snap.h"
 #include <stdbool.h>
 

--- a/tests/test_update_image.py
+++ b/tests/test_update_image.py
@@ -26,7 +26,6 @@ class TestUpdateImage(DeviceTestCase):
     def tearDown(self):
         util.test_track(self._testMethodName, started=False)
 
-    @unittest.skipIf(platform.release() == "4.18.0-408.el8.aarch64", "Broken on CentOS 8 with kernel 4.18.0-408.el8.aarch64. See #266")
     def test_update_sequence(self):
         iterations = 25
         file_name = "testfile"

--- a/utils/update-img.c
+++ b/utils/update-img.c
@@ -14,6 +14,7 @@
 #include <unistd.h>
 #include <string.h>
 
+#include "kernel-config.h"
 #include "libelastio-snap.h"
 
 #define INDEX_BUFFER_SIZE 8192


### PR DESCRIPTION
This PR introduces the working `update-img` utility and the working `test_update_sequence` check on Centos 8 + aarch64.

It was found that the update-img utility never actually worked on Centos 8 + aarch64. This was caused by the inconsistency of COW_BLOCK_SIZE in the driver and the utility itself because the last one didn't include the relevant kernel config (`kernel-config.h`).

Apart from that, the COW file overflow bug was found when `__cow_file_extents_zero_fill_ahead` was called from multiple places instead of just one (when the driver switches to the dormant state).

Both of these have been fixed in this PR.

Closes #266 