### PR TITLE
Fix test_track_writes failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
         # For now tests are taking up to 40 seconds per 1 fs on amd64 and about 2 minutes on arm64 or older 3.x kernels. But they can hang.
         # 20 minutes seems to be reasonable timeout.
-        timeout-minutes: 20
+        timeout-minutes: 25
 
       - name: Show debug information
         if: always()
@@ -201,7 +201,7 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
         # For now tests are taking 10-20 seconds per 1 fs on amd64 and about 2 minutes on arm64. But they can hang.
         # 20 minutes seems to be reasonable timeout.
-        timeout-minutes: 20
+        timeout-minutes: 25
 
       - name: Show debug information
         if: always()
@@ -218,7 +218,7 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
         # For now tests are taking up to 40 seconds per 1 fs on amd64 and about 2 minutes on arm64 or older 3.x kernels. But they can hang.
         # 20 minutes seems to be reasonable timeout.
-        timeout-minutes: 20
+        timeout-minutes: 25
 
       - name: Show debug information
         if: always()
@@ -257,7 +257,7 @@ jobs:
             vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh -d /dev/vdb1 -f $fs"
           done
         working-directory: ${{env.BOX_DIR}}
-        timeout-minutes: 25
+        timeout-minutes: 30
 
       - name: Show debug information
         if: always()
@@ -272,7 +272,7 @@ jobs:
             vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh -d /dev/vdb -d /dev/vdc -f $fs --lvm"
           done
         working-directory: ${{env.BOX_DIR}}
-        timeout-minutes: 25
+        timeout-minutes: 30
 
       - name: Show debug information
         if: always()
@@ -290,7 +290,7 @@ jobs:
             vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh -d /dev/vdb -d /dev/vdc -f $fs --raid"
           done
         working-directory: ${{env.BOX_DIR}}
-        timeout-minutes: 25
+        timeout-minutes: 30
 
       - name: Show debug information
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
         # For now tests are taking up to 40 seconds per 1 fs on amd64 and about 2 minutes on arm64 or older 3.x kernels. But they can hang.
         # 20 minutes seems to be reasonable timeout.
-        timeout-minutes: 25
+        timeout-minutes: 35
 
       - name: Show debug information
         if: always()
@@ -201,7 +201,7 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
         # For now tests are taking 10-20 seconds per 1 fs on amd64 and about 2 minutes on arm64. But they can hang.
         # 20 minutes seems to be reasonable timeout.
-        timeout-minutes: 25
+        timeout-minutes: 35
 
       - name: Show debug information
         if: always()
@@ -218,7 +218,7 @@ jobs:
         working-directory: ${{env.BOX_DIR}}
         # For now tests are taking up to 40 seconds per 1 fs on amd64 and about 2 minutes on arm64 or older 3.x kernels. But they can hang.
         # 20 minutes seems to be reasonable timeout.
-        timeout-minutes: 25
+        timeout-minutes: 35
 
       - name: Show debug information
         if: always()
@@ -257,7 +257,7 @@ jobs:
             vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh -d /dev/vdb1 -f $fs"
           done
         working-directory: ${{env.BOX_DIR}}
-        timeout-minutes: 30
+        timeout-minutes: 50
 
       - name: Show debug information
         if: always()
@@ -272,7 +272,7 @@ jobs:
             vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh -d /dev/vdb -d /dev/vdc -f $fs --lvm"
           done
         working-directory: ${{env.BOX_DIR}}
-        timeout-minutes: 30
+        timeout-minutes: 50
 
       - name: Show debug information
         if: always()
@@ -290,7 +290,7 @@ jobs:
             vagrant ssh ${{env.INSTANCE_NAME}} -c "cd tests && sudo ./elio-test.sh -d /dev/vdb -d /dev/vdc -f $fs --raid"
           done
         working-directory: ${{env.BOX_DIR}}
-        timeout-minutes: 30
+        timeout-minutes: 50
 
       - name: Show debug information
         if: always()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -77,8 +77,7 @@ class TestSnapshot(DeviceTestCase):
         info = elastio_snap.info(self.minor)
         start_nr = info["nr_changed_blocks"]
 
-        with open(testfile, "w") as f:
-            f.write("The quick brown fox")
+        util.dd("/dev/urandom", testfile, 1, bs="512")
 
         self.addCleanup(os.remove, testfile)
         os.sync()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -77,7 +77,7 @@ class TestSnapshot(DeviceTestCase):
         info = elastio_snap.info(self.minor)
         start_nr = info["nr_changed_blocks"]
 
-        util.dd("/dev/urandom", testfile, 1, bs="512")
+        util.dd("/dev/urandom", testfile, 1, bs="1M")
 
         self.addCleanup(os.remove, testfile)
         os.sync()


### PR DESCRIPTION
Long story short, it was proven to be not a bug but rather an incorrect test.

In some cases, we write to the sector already being tracked, which results in a
non-incrementing `nr_changed_blocks` counter. That happened because a small
amount of data was written (about 15 bytes) and the chances of writing to the
tracked sector were relatively high. The fix is to write more to increase the probability
of writing to the sector which isn't tracked.

Closes #167 