### PR TITLE
Fix Makefile to call genconfig.sh only once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ export BASE_DIR = $(abspath .)
 EUID := $(shell id -u -r)
 
 BUILDDIR := $(CURDIR)/pkgbuild
-KERNEL_CONFIG := src/kernel-config.h
+KERNEL_CONFIG := $(BASE_DIR)/src/kernel-config.h
 
 # Flags to pass to debbuild/rpmbuild
 PKGBUILDFLAGS := --define "_topdir $(BUILDDIR)" -ba --with devmode
@@ -29,11 +29,11 @@ ifneq ($(EUID),0)
 	@exit 1
 endif
 
-driver: check_root
-	$(MAKE) -C src
-
 $(KERNEL_CONFIG):
 	$(BASE_DIR)/src/genconfig.sh "$(shell uname -r)"
+
+driver: $(KERNEL_CONFIG) check_root
+	$(MAKE) -C src
 
 library-shared: $(KERNEL_CONFIG)
 	$(MAKE) -C lib CCFLAGS="$(CCFLAGS) -I$(BASE_DIR)/src" shared

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ endif
 FEATURE_TEST_BUILD_DIR := configure-tests/feature-tests/build
 
 default:
-	if [ ! -f kernel-config.h ] || tail -1 kernel-config.h | grep -qv '#endif'; then mkdir $(FEATURE_TEST_BUILD_DIR); ./genconfig.sh "$(KERNELVERSION)" "$(MFLAGS)"; fi;
+	if [ ! -f kernel-config.h ] || tail -1 kernel-config.h | grep -qv '#endif'; then ./genconfig.sh "$(KERNELVERSION)"; fi;
 	$(MAKE) -C $(KDIR) M=$(PWD) modules
 
 clean:


### PR DESCRIPTION
If called `make -B` after `make clean`, the behavior of Makefile was a bit inaccurate as we didn't 
track the `kernel-config.h` dependency for the `driver` target. This caused the `driver` target to
create `kernel-config.h` underneath and also forced the root Makefile to regenerate it as a "fresh
one". Hence, the script was called twice, which took twice more time.

Closes #280 