### PR TITLE
Fix compilation of nl_debug.o for v3.x & v4.x kernels

### DIFF
--- a/src/nl_debug.c
+++ b/src/nl_debug.c
@@ -21,6 +21,7 @@ int nl_send_event(enum msg_type_t type, const char *func, int line, struct param
 	struct sk_buff *skb;
 	struct msg_header_t *msg;
 	struct nlmsghdr *nlsk_mh;
+	struct timespec64 tspec;
 
 	skb = nlmsg_new(NLMSG_DEFAULT_SIZE, GFP_ATOMIC);
 	nlsk_mh = nlmsg_put(skb, 0, 0, NLMSG_DONE, sizeof(struct msg_header_t), 0);
@@ -30,7 +31,8 @@ int nl_send_event(enum msg_type_t type, const char *func, int line, struct param
 	spin_lock_bh(&nl_spinlock);
 	msg = nlmsg_data(nlsk_mh);
 	msg->type = type;
-	msg->timestamp = ktime_get();
+	ktime_get_ts64(&tspec);
+	msg->timestamp = timespec64_to_ns(&tspec);
 	msg->seq_num = seq_num;
 	seq_num++;
 


### PR DESCRIPTION
Minor fix to get a timestamp on all supported kernels

Closes #279 