### PR TITLE
Implement support kernel v6.4

### DIFF
--- a/src/configure-tests/feature-tests/bd_has_submit_bio.c
+++ b/src/configure-tests/feature-tests/bd_has_submit_bio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Copyright (C) 2020 Elastio Software Inc.
+ * Copyright (C) 2023 Elastio Software Inc.
  */
 
 #include "includes.h"

--- a/src/configure-tests/feature-tests/bd_has_submit_bio.c
+++ b/src/configure-tests/feature-tests/bd_has_submit_bio.c
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2020 Elastio Software Inc.
+ */
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct block_device *bdev;
+	bdev->bd_has_submit_bio = false;
+}


### PR DESCRIPTION
A new flag `bd_has_submit_bio` has been introduced in the new v6.4 Linux kernel. This flag defines if the `fops->submit_bio` or the other handler should be called. In this patch, we align the driver with this change by handling `bd_has_submit_bio` flag.

To do that, the `__tracer_transition_tracing` function has been rewritten to have access to the `tracing_params` struct through the `dev` pointer. Actually, this should have been done way earlier, because it was the question of time when we need the `dev` pointer (previously we passed `NULL` instead of the `dev` to end the tracing).

Apart from that, an additional compat has been added to check if the `bd_has_submit_bio` variable exists.

Closes #290 