### PR TITLE
Implement snapshot/incremental reload functionality

### DIFF
--- a/lib/libelastio-snap.c
+++ b/lib/libelastio-snap.c
@@ -234,9 +234,9 @@ int elastio_snap_transition_incremental(unsigned int minor){
 		if (elastio_snap_get_reload_params(minor, &rp) == 0) {
 			if (elastio_snap_set_reload_params(minor, false, &rp))
 				ret = ENOENT;
+		} else {
+			ret = ENOENT;
 		}
-	} else {
-		ret = ENOENT;
 	}
 
 	close(fd);
@@ -261,9 +261,9 @@ int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned lon
 			strcpy(rp.cow, cow);
 			if (elastio_snap_set_reload_params(minor, true, &rp))
 				ret = ENOENT;
+		} else {
+			ret = ENOENT;
 		}
-	} else {
-		ret = ENOENT;
 	}
 
 	close(fd);

--- a/lib/libelastio-snap.c
+++ b/lib/libelastio-snap.c
@@ -10,7 +10,95 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <sys/ioctl.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/stat.h>
 #include "libelastio-snap.h"
+
+#define RELOAD_SCRIPT_PATH		"/etc/elastio/dla"
+
+#define BUF_SIZE				512
+#define RELOAD_SCRIPT_BDEV_SIZE	128
+#define RELOAD_SCRIPT_COW_SIZE	256
+
+struct reload_script_params {
+	int snapshot;
+	unsigned int minor;
+	unsigned int cache_size;
+	int ignore_snap_errors;
+	char bdev[RELOAD_SCRIPT_BDEV_SIZE];
+	char cow[RELOAD_SCRIPT_COW_SIZE];
+};
+
+int elastio_snap_get_reload_params(unsigned int minor, struct reload_script_params *rp)
+{
+	FILE *fd;
+	int ret;
+	char buf[BUF_SIZE];
+	char filename[BUF_SIZE];
+	char mode[32] = { 0 };
+	char ignore_errors[16] = { 0 };
+
+	snprintf(filename, sizeof(filename), "%s/reload_%d.sh", RELOAD_SCRIPT_PATH, minor);
+
+	fd = fopen(filename, "r");
+	if (!fd)
+		return 1;
+
+	fread(buf, 1, BUF_SIZE, fd);
+	ret = sscanf(buf, "/usr/bin/elioctl reload-%s -c %u %s %s %u %s", mode, &rp->cache_size, rp->bdev, rp->cow, &rp->minor, ignore_errors);
+	if (ret != 5 && ret != 6) {
+		printf("reload script parsing error");
+		return -1;
+	}
+
+	if (!strcmp(ignore_errors, "-i"))
+		rp->ignore_snap_errors = 1;
+	else
+		rp->ignore_snap_errors = 0;
+
+	if (!strcmp(mode, "snapshot"))
+		rp->snapshot = 1;
+	else
+		rp->snapshot = 0;
+
+	fclose(fd);
+	return 0;
+}
+
+int elastio_snap_set_reload_params(unsigned int minor, bool snapshot, const struct reload_script_params *rp)
+{
+	FILE* fd;
+	char buf[BUF_SIZE];
+	char filename[BUF_SIZE];
+
+	snprintf(filename, sizeof(filename), "%s/reload_%d.sh", RELOAD_SCRIPT_PATH, minor);
+
+	memset(buf, 0, sizeof(buf));
+	fd = fopen(filename, "w");
+	if (!fd)
+		return 1;
+
+	int ret = snprintf(buf, sizeof(buf), "/usr/bin/elioctl reload-%s -c %u %s %s %u %s\n",
+			snapshot ? "snapshot" : "incremental", rp->cache_size, rp->bdev,
+			rp->cow, rp->minor, rp->ignore_snap_errors ? "-i" : "");
+
+	ret = fwrite(buf, 1, strlen(buf) + 1, fd);
+	if (ret == -1) {
+		perror("write error");
+		return 1;
+	}
+
+	fclose(fd);
+
+	if (chmod(filename, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH | S_IXGRP ) == -1) {
+		perror("set permissions error");
+		return 1;
+	}
+
+
+	return 0;
+}
 
 int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsigned long fallocated_space, unsigned long cache_size, bool ignore_snap_errors){
 	int fd, ret;
@@ -27,6 +115,18 @@ int elastio_snap_setup_snapshot(unsigned int minor, char *bdev, char *cow, unsig
 	sp.ignore_snap_errors = ignore_snap_errors;
 
 	ret = ioctl(fd, IOCTL_SETUP_SNAP, &sp);
+	if (ret == 0) {
+		struct reload_script_params rp;
+
+		rp.minor = minor;
+		rp.cache_size = cache_size;
+		rp.ignore_snap_errors = ignore_snap_errors;
+		strcpy(rp.bdev, bdev);
+		strcpy(rp.cow, cow);
+
+		if (elastio_snap_set_reload_params(minor, true, &rp))
+			perror("update script params");
+	}
 
 	close(fd);
 	return ret;
@@ -77,6 +177,13 @@ int elastio_snap_destroy(unsigned int minor){
 	if(fd < 0) return -1;
 
 	ret = ioctl(fd, IOCTL_DESTROY, &minor);
+	if (ret == 0) {
+		char buf[BUF_SIZE];
+
+		snprintf(buf, sizeof(buf), "%s/reload_%d.sh", RELOAD_SCRIPT_PATH, minor);
+		if (remove(buf))
+			perror("remove script reload file");
+	}
 
 	close(fd);
 	return ret;
@@ -89,6 +196,14 @@ int elastio_snap_transition_incremental(unsigned int minor){
 	if(fd < 0) return -1;
 
 	ret = ioctl(fd, IOCTL_TRANSITION_INC, &minor);
+	if (ret == 0) {
+		struct reload_script_params rp;
+		if (elastio_snap_get_reload_params(minor, &rp))
+			perror("get script params");
+
+		if (elastio_snap_set_reload_params(minor, false, &rp))
+			perror("update script params");
+	}
 
 	close(fd);
 	return ret;
@@ -106,6 +221,16 @@ int elastio_snap_transition_snapshot(unsigned int minor, char *cow, unsigned lon
 	if(fd < 0) return -1;
 
 	ret = ioctl(fd, IOCTL_TRANSITION_SNAP, &tp);
+	if (ret == 0) {
+		struct reload_script_params rp;
+		if (elastio_snap_get_reload_params(minor, &rp))
+			perror("get script params");
+
+		strcpy(rp.cow, cow);
+
+		if (elastio_snap_set_reload_params(minor, true, &rp))
+			perror("update script params");
+	}
 
 	close(fd);
 	return ret;
@@ -122,6 +247,16 @@ int elastio_snap_reconfigure(unsigned int minor, unsigned long cache_size){
 	rp.cache_size = cache_size;
 
 	ret = ioctl(fd, IOCTL_RECONFIGURE, &rp);
+	if (ret == 0) {
+		struct reload_script_params rp;
+		if (elastio_snap_get_reload_params(minor, &rp))
+			perror("get script params");
+
+		rp.cache_size = cache_size;
+
+		if (elastio_snap_set_reload_params(minor, rp.snapshot, &rp))
+			perror("update script params");
+	}
 
 	close(fd);
 	return ret;


### PR DESCRIPTION
The main concept is to create a reload script when the snapshot is created or changes its state, allowing the kernel to call it before the root file system is mounted. This functionality has been implemented in libelastio-snap as it's used in both elastio and elioctl.

Works everywhere but Fedora 38, Ubuntu 20.04 and Ubuntu 22.04. The relevant issue is here: #292,

Closes #289 