### PR TITLE
Reload doesn't work on Ubuntu & Fedora

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -6189,6 +6189,9 @@ static int __handle_bdev_mount_nowrite(const struct vfsmount *mnt, unsigned int 
 	tracer_for_each(dev, i){
 		if(!dev || !test_bit(ACTIVE, &dev->sd_state) || tracer_read_fail_state(dev) || dev->sd_base_dev != mnt->mnt_sb->s_bdev) continue;
 
+		if (mnt->mnt_root != elastio_snap_get_mnt(dev->sd_cow->filp)->mnt_root)
+			continue;
+
 		LOG_DEBUG("block device umount detected for device %d", i);
 		auto_transition_dormant(i);
 
@@ -6257,7 +6260,7 @@ static int handle_bdev_mount_event(const char __user *dir_name, int follow_flags
 
 	if(!(follow_flags & UMOUNT_NOFOLLOW)) lookup_flags |= LOOKUP_FOLLOW;
 
-	ret = user_path_at(0, dir_name, lookup_flags, &path);
+	ret = user_path_at(AT_FDCWD, dir_name, lookup_flags, &path);
 	if(ret){
 		//error finding path
 		goto out;

--- a/src/main.c
+++ b/src/main.c
@@ -6260,7 +6260,7 @@ static int handle_bdev_mount_event(const char __user *dir_name, int follow_flags
 
 	if(!(follow_flags & UMOUNT_NOFOLLOW)) lookup_flags |= LOOKUP_FOLLOW;
 
-	ret = user_path_at(AT_FDCWD, dir_name, lookup_flags, &path);
+	ret = user_path_at(0, dir_name, lookup_flags, &path);
 	if(ret){
 		//error finding path
 		goto out;

--- a/src/main.c
+++ b/src/main.c
@@ -6257,7 +6257,7 @@ static int handle_bdev_mount_event(const char __user *dir_name, int follow_flags
 
 	if(!(follow_flags & UMOUNT_NOFOLLOW)) lookup_flags |= LOOKUP_FOLLOW;
 
-	ret = user_path_at(AT_FDCWD, dir_name, lookup_flags, &path);
+	ret = user_path_at(0, dir_name, lookup_flags, &path);
 	if(ret){
 		//error finding path
 		goto out;


### PR DESCRIPTION
This patch introduces two fixes for Fedora and Ubuntu distributives to make the reload functionality work.

In general, this resolves the issues with false umounts. For Fedora, it was seen that the umount of the '.' directory took place during operation. There were no results in finding the exact instance that does it and why, but it doesn't look okay for regular operation. Hence, the code was corrected to accept only absolute paths instead of absolute + relative (as in this situation).

For Ubuntu the problem was different. Additional mount points were created for the root volume, which caused false umount handling in the driver. To fix that, we now check the vfsmount pointers to ensure we are dealing with the initial root volume.

Closes #292 