### PR TITLE
Fix snapshot reload on ec2 instances

### DIFF
--- a/dist/initramfs/reload
+++ b/dist/initramfs/reload
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ls -l /etc/elastio/dla/mnt/etc/elastio/dla/reload_* > /dev/null 2>&1
+ls /etc/elastio/dla/mnt/etc/elastio/dla/reload_* > /dev/null 2>&1
 
 if [ "$?" = "0" ]; then
 	FILES="/etc/elastio/dla/mnt/etc/elastio/dla/reload_*"


### PR DESCRIPTION
Apparently, AWS has patched its base utils, which works differently when we try to use our scripts.
In this particular case, their `ls` utility doesn't support a [real basic] flag `-l`. This caused our reload
script to crash without reloading the subscripts for each particular volume that is tracked by the
driver.

Closes #297 